### PR TITLE
chore: bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darwin-v7"
-version = "0.1.31"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 description = "Unofficial rust client for the [V7 annotation platform](https://darwin.v7labs.com/)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darwin-v7"
-version = "0.1.3"
+version = "0.1.31"
 edition = "2021"
 license = "MIT"
 description = "Unofficial rust client for the [V7 annotation platform](https://darwin.v7labs.com/)"


### PR DESCRIPTION
## What

Version 0.1.31

Releases Export Structs for V7 Annotations