### PR TITLE
feat: add complex_polygon as an annotation_type

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -38,7 +38,7 @@ pub struct Polygon {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
 pub struct ComplexPolygon {
-    pub path: Vec<Vec<Keypoint>>,
+    pub path: Vec<Polygon>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -37,6 +37,11 @@ pub struct Polygon {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
+pub struct ComplexPolygon {
+    pub path: Vec<Vec<Keypoint>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
 pub struct Keypoint {
     // The horizontal coordinate of the keypoint
     pub x: f32,
@@ -52,11 +57,6 @@ pub struct Text {
     pub text: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
-pub struct Line {
-    pub path: Vec<Keypoint>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, EnumString, Display)]
 #[serde(rename_all = "lowercase")]
 #[serde(untagged)]
@@ -67,6 +67,8 @@ pub enum AnnotationType {
     #[serde(rename = "bounding_box")]
     #[strum(serialize = "bounding_box")]
     BoundingBox(BoundingBox),
+    #[strum(serialize = "complex_polygon")]
+    ComplexPolygon(ComplexPolygon),
     Cuboid,
     #[serde(rename = "directional_vector")]
     DirectionalVector,
@@ -77,11 +79,11 @@ pub enum AnnotationType {
     InstanceId,
     #[strum(serialize = "keypoint")]
     Keypoint(Keypoint),
-    #[strum(serialize = "line")]
-    Line(Line),
+    Line,
     Measures,
     #[strum(serialize = "polygon")]
     Polygon(Polygon),
+
     Skeleton,
     #[strum(serialize = "tag")]
     Tag(Tag),
@@ -116,12 +118,13 @@ impl From<AnnotationType> for u32 {
             AnnotationType::AutoAnnotate => todo!(),
             AnnotationType::BoundingBox(_) => 2,
             AnnotationType::Cuboid => todo!(),
+            AnnotationType::ComplexPolygon(_) => todo!(),
             AnnotationType::DirectionalVector => todo!(),
             AnnotationType::Ellipse => todo!(),
             AnnotationType::Inference => todo!(),
             AnnotationType::InstanceId => todo!(),
             AnnotationType::Keypoint(_) => todo!(),
-            AnnotationType::Line(_) => 11,
+            AnnotationType::Line => 11,
             AnnotationType::Measures => todo!(),
             AnnotationType::Polygon(_) => 3,
             AnnotationType::Skeleton => 12,
@@ -140,12 +143,13 @@ impl AnnotationType {
             "auto_annotate" => AnnotationType::AutoAnnotate,
             "bounding_box" => AnnotationType::BoundingBox(Default::default()),
             "cuboid" => AnnotationType::Cuboid,
+            "complex_polygon" => AnnotationType::ComplexPolygon(Default::default()),
             "directional_vector" => AnnotationType::DirectionalVector,
             "ellipse" => AnnotationType::Ellipse,
             "inference" => AnnotationType::Inference,
             "instance_id" => AnnotationType::InstanceId,
             "keypoint" => AnnotationType::Keypoint(Default::default()),
-            "line" => AnnotationType::Line(Default::default()),
+            "line" => AnnotationType::Line,
             "measures" => AnnotationType::Measures,
             "polygon" => AnnotationType::Polygon(Default::default()),
             "skeleton" => AnnotationType::Skeleton,

--- a/src/export.rs
+++ b/src/export.rs
@@ -53,8 +53,7 @@ pub struct ImageAnnotation {
     #[serde(alias = "skeleton", alias = "tag")]
     pub annotation_type_1: Option<AnnotationType>,
 
-    #[serde(alias = "ellipse", alias = "line")]
-    #[serde(alias = "keypoint", alias = "polygon")]
+    #[serde(alias = "keypoint", alias = "polygon", alias = "complex_polygon")]
     pub annotation_type_2: Option<AnnotationType>,
 }
 
@@ -81,17 +80,23 @@ mod tests {
                     }
                   ],
                   "id": "fb81c35c-716a-413a-81e8-16ae9c054490",
-                  "line": {
-                      "path": [
-                          {
-                            "x": 103.92,
-                            "y": 196.48
-                          },
-                          {
-                            "x": 192.83,
-                            "y": 123.58
-                          }
-                        ]
+                  "bounding_box": {
+                    "h": 588.75,
+                    "w": 630.9500000000116,
+                    "x": 88527.01,
+                    "y": 11805.9
+                  },
+                  "complex_polygon": {
+                    "path": [
+                    [
+                      {
+                        "x": 89094.67,
+                        "y": 11924.8
+                      }], [
+                      {
+                        "x": 89094.67,
+                        "y": 11924.8
+                      }]]
                   },
                   "name": "something"
                 }


### PR DESCRIPTION
## What

This PR adds a type complex_polygon - even though conceptually it is a list of polygons, exports from V7 include the annotation type as "complex_polygon" differing from "polygon". Adding a separate type helps clarify the structure of the polygon parsed.

 