### PR TITLE
fix: Remove metadata from Export results

### DIFF
--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -80,8 +80,8 @@ pub struct Export {
     pub format: ExportFormat,
     pub inserted_at: String,
     pub latest: bool,
-    #[serde(skip_serializing)]
-    pub metadata: ExportMetadata,
+    // #[serde(skip_serializing)]
+    // pub metadata: ExportMetadata,
     pub status: Option<String>,
     pub version: u16,
 }

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -80,8 +80,8 @@ pub struct Export {
     pub format: ExportFormat,
     pub inserted_at: String,
     pub latest: bool,
-    // #[serde(skip_serializing)]
-    // pub metadata: ExportMetadata,
+    #[serde(skip_deserializing)]
+    pub metadata: ExportMetadata,
     pub status: Option<String>,
     pub version: u16,
 }


### PR DESCRIPTION
Comment out the ExportMetadata as it is not being returned from V7 