### PR TITLE
fix: Fix ComplexPolygon parsing

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -38,7 +38,7 @@ pub struct Polygon {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
 pub struct ComplexPolygon {
-    pub path: Vec<Polygon>,
+    pub path: Vec<Vec<Keypoint>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
@@ -67,6 +67,7 @@ pub enum AnnotationType {
     #[serde(rename = "bounding_box")]
     #[strum(serialize = "bounding_box")]
     BoundingBox(BoundingBox),
+    #[serde(rename = "complex_polygon")]
     #[strum(serialize = "complex_polygon")]
     ComplexPolygon(ComplexPolygon),
     Cuboid,

--- a/src/export.rs
+++ b/src/export.rs
@@ -101,7 +101,13 @@ mod tests {
                   "name": "something"
                 }
         "#;
-        let _: ImageAnnotation = serde_json::from_str(raw_json)?;
+        let annotation: ImageAnnotation = serde_json::from_str(raw_json)?;
+        match annotation.annotation_type_2 {
+            Some(AnnotationType::ComplexPolygon(_)) => {}
+            _ => {
+                assert!(false);
+            }
+        };
         Ok(())
     }
 


### PR DESCRIPTION
This PR fixes the type definition of ComplexPolygons, and adds an explicit test to make sure we're getting what we expect in the unit test that tests for parsing.

Previously the complex polygon was decoding to a `Tag`, but we didn't actually check this in the test.