### PR TITLE
fix: comment_tread to comment_threads route typo

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -79,7 +79,7 @@ where
     ) -> Result<CommentThreadResponse> {
         let response = client
             .post(
-                &format!("v2/teams/{}/items/{}/comment_thread", team_slug, self.id),
+                &format!("v2/teams/{}/items/{}/comment_threads", team_slug, self.id),
                 &data,
             )
             .await?;


### PR DESCRIPTION
There's a typo in the POST route we use to add a comment to an item.

Source: https://docs.v7labs.com/reference/comments-thread-create