### PR TITLE
fix: response status code on setting a workflow is 201

### DIFF
--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -675,8 +675,11 @@ where
         let response = client
             .post(&format!("v2/teams/{}/workflows", client.team()), workflow)
             .await?;
-
-        expect_http_ok!(response, WorkflowV2)
+        // 201 is correct operation for this endpoint
+        if response.status() != 201 {
+            bail!("Invalid status code {}", response.status())
+        }
+        Ok(response.json().await?)
     }
 
     async fn set_default_workflow(


### PR DESCRIPTION
This PR fixes the response status code to check for 201 rather than 200 to set the workflow to a dataset successfully 