### PR TITLE
fix: Comment thread response type

### DIFF
--- a/src/classes.rs
+++ b/src/classes.rs
@@ -2,10 +2,10 @@
 use fake::{Dummy, Fake};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
 pub struct BoundingBox {
     pub x: i32,
     pub y: i32,
-    pub w: u32,
-    pub h: u32,
+    pub w: f32,
+    pub h: f32,
 }

--- a/src/classes.rs
+++ b/src/classes.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
 pub struct BoundingBox {
-    pub x: i32,
-    pub y: i32,
+    pub x: f32,
+    pub y: f32,
     pub w: f32,
     pub h: f32,
 }

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -47,9 +47,9 @@ pub struct CommentLine {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
 pub struct CommentThreadResponse {
-    pub author_id: u32,
+    pub author_id: f32,
     pub bounding_box: BoundingBox,
-    pub comment_count: u32,
+    pub comment_count: f32,
     pub dataset_item_id: String,
     pub first_comment: CommentLine,
     pub id: String,

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -34,9 +34,9 @@ where
     ) -> Result<CommentThreadResponse>;
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
 pub struct CommentLine {
-    pub author_id: u32,
+    pub author_id: f32,
     pub body: String,
     pub comment_thread_id: String,
     pub created_by_system: bool,

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -45,7 +45,7 @@ pub struct CommentLine {
     pub updated_at: String,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
 pub struct CommentThreadResponse {
     pub author_id: f32,
     pub bounding_box: BoundingBox,

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -14,7 +14,7 @@ pub struct CommentBody {
     pub body: String,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
 pub struct CommentThread {
     pub bounding_box: BoundingBox,
     pub comments: Vec<CommentBody>,

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -36,7 +36,7 @@ where
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
 pub struct CommentLine {
-    pub author_id: f32,
+    pub author_id: u32,
     pub body: String,
     pub comment_thread_id: String,
     pub created_by_system: bool,
@@ -47,9 +47,9 @@ pub struct CommentLine {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
 pub struct CommentThreadResponse {
-    pub author_id: f32,
+    pub author_id: u32,
     pub bounding_box: BoundingBox,
-    pub comment_count: f32,
+    pub comment_count: u32,
     pub dataset_item_id: String,
     pub first_comment: CommentLine,
     pub id: String,

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -117,13 +117,13 @@ pub struct WorkflowBody {
     pub body: String,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
 pub struct LocatedWorkflowComments {
     pub bounding_box: BoundingBox,
     pub workflow_comments: Vec<WorkflowBody>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
 pub struct WorkflowCommentThread {
     pub author_id: u32,
     pub bounding_box: BoundingBox,


### PR DESCRIPTION
## For the Reviewer

In this repo, we try to follow the [conventional comments](https://conventionalcomments.org/) guidebook when providing feedback to PRs. Please follow the guidebook, to make reviewing a smoother experience for you and me!

## What

Changes the value types for `BoundingBox` to `f32`, as the Darwin API was returning floats in responses.
Also removes `Eq` traits from anything that consumes a `BoundingBox`, as floats don't implement `Eq`.

## Why

So we can make API calls that work, because we get deserialisation errors on response otherwise.
