### PR TITLE
feat: Add dataset update route to change batch size

### DIFF
--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -94,16 +94,15 @@ impl From<&Dataset> for DatasetUpdate {
     fn from(value: &Dataset) -> Self {
         DatasetUpdate {
             annotation_hotkeys: value.annotation_hotkeys.clone(),
-            annotators_can_create_tags: value.annotators_can_create_tags.clone(),
+            annotators_can_create_tags: value.annotators_can_create_tags,
             annotators_can_instantiate_workflows: value
-                .annotators_can_instantiate_workflows
-                .clone(),
-            anyone_can_double_assign: value.anyone_can_double_assign.clone(),
+                .annotators_can_instantiate_workflows,
+            anyone_can_double_assign: value.anyone_can_double_assign,
             instructions: value.instructions.clone(),
             name: value.name.clone(),
-            public: value.public.clone(),
-            reviewers_can_annotate: value.reviewers_can_annotate.clone(),
-            work_size: value.work_size.clone(),
+            public: value.public,
+            reviewers_can_annotate: value.reviewers_can_annotate,
+            work_size: value.work_size,
             work_prioritization: value.work_prioritization.clone(),
         }
     }
@@ -509,7 +508,7 @@ where
 
     async fn update_batch_size(&self, client: &C, size: &u32) -> Result<()> {
         let mut payload = DatasetUpdate::from(self);
-        payload.work_size = Some(size.clone().into()); // this PUT path requires every parameter
+        payload.work_size = Some(*size); // this PUT path requires every parameter
                                                        // even if we're not updating them
                                                        // so we have to replicate the rest of the existing settings
 

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -95,8 +95,7 @@ impl From<&Dataset> for DatasetUpdate {
         DatasetUpdate {
             annotation_hotkeys: value.annotation_hotkeys.clone(),
             annotators_can_create_tags: value.annotators_can_create_tags,
-            annotators_can_instantiate_workflows: value
-                .annotators_can_instantiate_workflows,
+            annotators_can_instantiate_workflows: value.annotators_can_instantiate_workflows,
             anyone_can_double_assign: value.anyone_can_double_assign,
             instructions: value.instructions.clone(),
             name: value.name.clone(),
@@ -509,8 +508,8 @@ where
     async fn update_batch_size(&self, client: &C, size: &u32) -> Result<()> {
         let mut payload = DatasetUpdate::from(self);
         payload.work_size = Some(*size); // this PUT path requires every parameter
-                                                       // even if we're not updating them
-                                                       // so we have to replicate the rest of the existing settings
+                                         // even if we're not updating them
+                                         // so we have to replicate the rest of the existing settings
 
         let response = client
             .put(&format!("datasets/{}", self.id), Some(&payload))


### PR DESCRIPTION
## For the Reviewer

In this repo, we try to follow the [conventional comments](https://conventionalcomments.org/) guidebook when providing feedback to PRs. Please follow the guidebook, to make reviewing a smoother experience for you and me!

## What

Adds a method on `DatasetDataMethods` for `update_batch_size` to change the task batch size in a dataset (read: the number of items a labeller can self-assign at a single time).

## Why

So we can limit the number of items labellers are self-assigning from their datasets.
