### PR TITLE
Fix: v2 annotation types

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -31,14 +31,19 @@ pub struct BoundingBox {
     pub y: f32,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
-pub struct Polygon {
-    pub path: Vec<Keypoint>,
-}
+// This may be deprecated in Darwin JSON v2.0.
+// #[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
+// pub struct Polygon {
+//     pub path: Vec<Keypoint>,
+// }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
 pub struct ComplexPolygon {
     pub path: Vec<Vec<Keypoint>>,
+}
+
+pub struct Polygon{
+    pub paths: Vec<Vec<Keypoint>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
@@ -67,9 +72,11 @@ pub enum AnnotationType {
     #[serde(rename = "bounding_box")]
     #[strum(serialize = "bounding_box")]
     BoundingBox(BoundingBox),
-    #[serde(rename = "complex_polygon")]
-    #[strum(serialize = "complex_polygon")]
-    ComplexPolygon(ComplexPolygon),
+
+    // This type does not seem to exist in Darwin JSON v2.0
+    // #[serde(rename = "complex_polygon")]
+    // #[strum(serialize = "complex_polygon")]
+    // ComplexPolygon(ComplexPolygon),
     Cuboid,
     #[serde(rename = "directional_vector")]
     DirectionalVector,

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -31,17 +31,6 @@ pub struct BoundingBox {
     pub y: f32,
 }
 
-// This may be deprecated in Darwin JSON v2.0.
-// #[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
-// pub struct Polygon {
-//     pub path: Vec<Keypoint>,
-// }
-
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
-pub struct ComplexPolygon {
-    pub path: Vec<Vec<Keypoint>>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
 pub struct Polygon {
     pub paths: Vec<Vec<Keypoint>>,
@@ -73,11 +62,6 @@ pub enum AnnotationType {
     #[serde(rename = "bounding_box")]
     #[strum(serialize = "bounding_box")]
     BoundingBox(BoundingBox),
-
-    // This type does not seem to exist in Darwin JSON v2.0
-    // #[serde(rename = "complex_polygon")]
-    // #[strum(serialize = "complex_polygon")]
-    // ComplexPolygon(ComplexPolygon),
     Cuboid,
     #[serde(rename = "directional_vector")]
     DirectionalVector,
@@ -127,7 +111,6 @@ impl From<AnnotationType> for u32 {
             AnnotationType::AutoAnnotate => todo!(),
             AnnotationType::BoundingBox(_) => 2,
             AnnotationType::Cuboid => todo!(),
-            // AnnotationType::ComplexPolygon(_) => todo!(),
             AnnotationType::DirectionalVector => todo!(),
             AnnotationType::Ellipse => todo!(),
             AnnotationType::Inference => todo!(),
@@ -152,7 +135,6 @@ impl AnnotationType {
             "auto_annotate" => AnnotationType::AutoAnnotate,
             "bounding_box" => AnnotationType::BoundingBox(Default::default()),
             "cuboid" => AnnotationType::Cuboid,
-            // "complex_polygon" => AnnotationType::ComplexPolygon(Default::default()),
             "directional_vector" => AnnotationType::DirectionalVector,
             "ellipse" => AnnotationType::Ellipse,
             "inference" => AnnotationType::Inference,

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -42,7 +42,8 @@ pub struct ComplexPolygon {
     pub path: Vec<Vec<Keypoint>>,
 }
 
-pub struct Polygon{
+#[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
+pub struct Polygon {
     pub paths: Vec<Vec<Keypoint>>,
 }
 
@@ -126,7 +127,7 @@ impl From<AnnotationType> for u32 {
             AnnotationType::AutoAnnotate => todo!(),
             AnnotationType::BoundingBox(_) => 2,
             AnnotationType::Cuboid => todo!(),
-            AnnotationType::ComplexPolygon(_) => todo!(),
+            // AnnotationType::ComplexPolygon(_) => todo!(),
             AnnotationType::DirectionalVector => todo!(),
             AnnotationType::Ellipse => todo!(),
             AnnotationType::Inference => todo!(),
@@ -151,7 +152,7 @@ impl AnnotationType {
             "auto_annotate" => AnnotationType::AutoAnnotate,
             "bounding_box" => AnnotationType::BoundingBox(Default::default()),
             "cuboid" => AnnotationType::Cuboid,
-            "complex_polygon" => AnnotationType::ComplexPolygon(Default::default()),
+            // "complex_polygon" => AnnotationType::ComplexPolygon(Default::default()),
             "directional_vector" => AnnotationType::DirectionalVector,
             "ellipse" => AnnotationType::Ellipse,
             "inference" => AnnotationType::Inference,

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,7 +1,7 @@
 //! This file contains structures and methods that define the Darwin Export Format
 //! https://docs.v7labs.com/v1.0/reference/darwin-json
 
-use crate::annotation::AnnotationType;
+use crate::annotation::{BoundingBox, Polygon, Tag, Text};
 use crate::item::DatasetItemTypes;
 use serde::{Deserialize, Serialize};
 
@@ -48,14 +48,18 @@ pub struct ImageAnnotation {
     pub annotators: Option<Vec<Annotator>>,
     // An optional list of reviewers of the image
     pub reviewers: Option<Vec<Annotator>>,
-
-    //// The actual data of the annotation
-    #[serde(alias = "bounding_box", alias = "cuboid")]
-    #[serde(alias = "skeleton", alias = "tag")]
-    pub annotation_type_1: Option<AnnotationType>,
-
-    #[serde(alias = "keypoint", alias = "polygon", alias = "complex_polygon")]
-    pub annotation_type_2: Option<AnnotationType>,
+    // Annotation Type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bounding_box: Option<BoundingBox>,
+    // Annotation Type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<Tag>,
+    // Annotation Type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub polygon: Option<Polygon>,
+    // Annotation Type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<Text>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -123,90 +127,6 @@ pub struct JsonExportV2 {
 mod tests {
     use super::*;
     use anyhow::Result;
-
-    #[test]
-    fn test_v7_annotation_export_lines() -> Result<()> {
-        let raw_json = r#"
-                {
-                  "annotators": [
-                    {
-                      "email": "abc.xyz@cheese.com",
-                      "full_name": "ABC XYZ"
-                    }
-                  ],
-                  "id": "fb81c35c-716a-413a-81e8-16ae9c054490",
-                  "bounding_box": {
-                    "h": 588.75,
-                    "w": 630.9500000000116,
-                    "x": 88527.01,
-                    "y": 11805.9
-                  },
-                  "complex_polygon": {
-                    "path": [
-                    [
-                      {
-                        "x": 89094.67,
-                        "y": 11924.8
-                      }], [
-                      {
-                        "x": 89094.67,
-                        "y": 11924.8
-                      }]]
-                  },
-                  "name": "something"
-                }
-        "#;
-        let annotation: ImageAnnotation = serde_json::from_str(raw_json)?;
-        match annotation.annotation_type_2 {
-            Some(AnnotationType::ComplexPolygon(_)) => {}
-            _ => {
-                assert!(false);
-            }
-        };
-        Ok(())
-    }
-
-    #[test]
-    fn test_full_v7_export_file() -> Result<()> {
-        let contents = r#"
-        {
-          "dataset": "Test Dataset",
-          "image": {
-            "filename": "xxxx-xxxx-xxxx-xxxx-xxxx.xxxx",
-            "height": 88149,
-            "original_filename": "xxxxx-xxxx-xxxx-xxxx-xxxx.xxxx",
-            "path": "/",
-            "thumbnail_url": "https://darwin.v7labs.com/api/images/999/thumbnail",
-            "url": "https://darwin.v7labs.com/api/images/999/original",
-            "width": 188688,
-            "workview_url": "https://darwin.v7labs.com/workview?dataset=999&image=54"
-          },
-          "annotations": [
-            {
-              "bounding_box": {
-                "h": 588.75,
-                "w": 630.9500000000116,
-                "x": 88527.01,
-                "y": 11805.9
-              },
-              "id": "770e4a19-a350-4d5e-964e-783512a508f9",
-              "name": "Cheese",
-              "polygon": {
-                "path": [
-                  {
-                    "x": 89094.67,
-                    "y": 11924.8
-                  }]
-              }
-            }
-          ]
-        }
-        "#;
-        let export: JsonExport = serde_json::from_str(contents).expect("Error parsing V7 Export");
-        assert!(export.annotations[0].annotation_type_2.is_some());
-        Ok(())
-    }
-
     #[test]
     fn test_full_v7_export_v2_file() -> Result<()> {
         let contents = r#"
@@ -257,11 +177,12 @@ mod tests {
               "id": "770e4a19-a350-4d5e-964e-783512a508f9",
               "name": "Cheese",
               "polygon": {
-                "path": [
+                "paths": [[
                   {
                     "x": 89094.67,
                     "y": 11924.8
-                  }]
+                  }
+                ]]
               },
 
               "reviewers": [
@@ -280,7 +201,10 @@ mod tests {
         "#;
         let export: JsonExportV2 = serde_json::from_str(contents).expect("Error parsing V7 Export");
         assert_eq!(export.version, "2.0");
-        assert!(export.annotations[0].annotation_type_2.is_some());
+        assert_eq!(
+            export.annotations[0].polygon.clone().unwrap().paths.len(),
+            1
+        );
         Ok(())
     }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -111,7 +111,8 @@ pub struct Slot {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SourceFile {
     pub file_name: String,
-    pub storage_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_key: Option<String>,
     pub url: String,
 }
 

--- a/src/export.rs
+++ b/src/export.rs
@@ -205,6 +205,7 @@ mod tests {
             export.annotations[0].polygon.clone().unwrap().paths.len(),
             1
         );
+        assert!(export.annotations[0].tag.is_none());
         Ok(())
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,13 @@ macro_rules! expect_http_ok {
                 $x.text().await?
             ))
         } else {
-            Ok($x.json::<$y>().await?)
+            let text = $x.text().await?;
+            let res = serde_json::from_str::<$y>(&text);
+            if (res.is_err()) {
+                bail!("{}\n{}", text, res.err().unwrap())
+            }
+
+            Ok(res?)
         }
     };
 }

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -264,6 +264,9 @@ pub struct WorkflowV2 {
     pub team_id: u32,
     pub thumbnails: Vec<String>,
     pub updated_at: String,
+    pub work_batch_requested: bool,
+    #[serde(rename = "additionalProp")]
+    pub additional_prop: u32,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -264,9 +264,11 @@ pub struct WorkflowV2 {
     pub team_id: u32,
     pub thumbnails: Vec<String>,
     pub updated_at: String,
-    pub work_batch_requested: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work_batch_requested: Option<bool>,
     #[serde(rename = "additionalProp")]
-    pub additional_prop: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_prop: Option<u32>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -262,7 +262,7 @@ pub struct WorkflowV2 {
     pub progress: WorkflowProgress,
     pub stages: Vec<WorkflowStageV2>,
     pub team_id: u32,
-    pub thumbnails: Vec<String>,
+    pub thumbnails: Vec<Option<String>>,
     pub updated_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub work_batch_requested: Option<bool>,


### PR DESCRIPTION
## What

Updates Darwin JSON v2.0 struct for annotations and explicitly defines the annotation type as a bounding box or polygon or tag

