### PR TITLE
fix: Make item ids filter a String instead of a u32

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -74,10 +74,10 @@ pub struct Filter {
     pub evaluation_metrics_run_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub not_item_ids: Option<Vec<u32>>,
+    pub not_item_ids: Option<Vec<String>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub item_ids: Option<Vec<u32>>,
+    pub item_ids: Option<Vec<String>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dataset_ids: Option<Vec<u32>>,


### PR DESCRIPTION
## For the Reviewer

In this repo, we try to follow the [conventional comments](https://conventionalcomments.org/) guidebook when providing feedback to PRs. Please follow the guidebook, to make reviewing a smoother experience for you and me!

## What

Fixes the value type for `item_ids` in the `Filter` struct, correctly making it a `Vec<String>` instead of a `Vec<u32>`.

## Why

Because the V7 API represents `item_ids` as UUIDs, which are Strings.
