### PR TITLE
feat:  migrate annotation import #FRADATA-543

### DIFF
--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -642,10 +642,10 @@ where
     ) -> Result<()> {
         let endpoint = format!(
             "v2/teams/{team_slug}/items/{item_id}/import",
-            team_slug = self
-                .team_slug
-                .as_ref()
-                .with_context(|| format!("Dataset is missing team slug. dataset slug: {}", self.slug))?
+            team_slug = self.team_slug.as_ref().with_context(|| format!(
+                "Dataset is missing team slug. dataset slug: {}",
+                self.slug
+            ))?
         );
         let response = client.post(&endpoint, annotation_import).await?;
         let status = response.status();

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -385,6 +385,18 @@ where
         client: &C,
         hotkeys: HashMap<String, String>,
     ) -> Result<()>;
+
+    /// Asynchronously imports an annotation into this dataset.
+    ///
+    /// This function takes a reference to a client, an item ID, and an annotation import object,
+    /// and attempts to add the annotation to the specified item in the dataset. The operation
+    /// is performed asynchronously.
+    ///
+    /// # Arguments
+    /// * `client` - A reference to the client used to access V7.
+    /// * `item_id` - The identifier of the item to which the annotation should be added.
+    /// * `annotation_import` - A reference to the `AnnotationImport` object containing the
+    ///   annotation data to be imported.
     async fn import_annotation(
         &self,
         client: &C,
@@ -609,6 +621,19 @@ where
         Ok(())
     }
 
+    /// Asynchronously imports an annotation into a dataset.
+    ///
+    /// Posts `annotation_import` data to a constructed endpoint using `item_id`. Checks for
+    /// a successful 200 HTTP response status. Errors if the dataset lacks a team slug or
+    /// if the response status indicates failure.
+    ///
+    /// # Arguments
+    /// * `client` - Client for HTTP operations.
+    /// * `item_id` - Identifier for the target item.
+    /// * `annotation_import` - Data for the annotation to be imported.
+    ///
+    /// # Returns
+    /// `Result<()>` indicating success or failure.
     async fn import_annotation(
         &self,
         client: &C,
@@ -620,12 +645,12 @@ where
             team_slug = self
                 .team_slug
                 .as_ref()
-                .context("Dataset is missing team slug")?
+                .with_context(|| format!("Dataset is missing team slug. dataset slug: {}", self.slug))?
         );
         let response = client.post(&endpoint, annotation_import).await?;
         let status = response.status();
         if status != 200 {
-            bail!("Invalid status code {status}");
+            bail!("Import Annotation: Invalid status code {status}");
         }
         Ok(())
     }

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -85,7 +85,7 @@ fn _find_annotation_class_id(
 }
 
 impl AnnotationImportAnnotation {
-    fn new_polygon_annotation(
+    pub fn new_polygon_annotation(
         original_annotation: &ImageAnnotation,
         path: Vec<Keypoint>,
         eligible_annotation_classes: &[&AnnotationClass],
@@ -104,7 +104,7 @@ impl AnnotationImportAnnotation {
         })
     }
 
-    fn new_tag_annotation(
+    pub fn new_tag_annotation(
         original_annotation: &ImageAnnotation,
         eligible_annotation_classes: &[&AnnotationClass],
         slot_name: &str,

--- a/src/imports.rs
+++ b/src/imports.rs
@@ -1,0 +1,127 @@
+use crate::{
+    annotation::{AnnotationClass, Keypoint, Tag},
+    export::ImageAnnotation,
+};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Struct representing the payload data wrapper of a V7 annotation suitable for importing back into a V7 dataset item
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AnnotationImportData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub polygon: Option<AnnotationImportPolygon>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<Tag>,
+}
+
+/// Struct representing the polygon payload data of a V7 annotation suitable for importing back into a V7 dataset item
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AnnotationImportPolygon {
+    /// V7 provides no documentation on the format of these polygons on import.
+    /// We assume though that these Keypoints are ordered in some way that represents a closed polygon.
+    /// Typically, we import annotations as-is from V7 exports and retain the ordering as they were exported.
+    /// This may change when we start merging polygons to import those merged polygons instead.
+    pub path: Vec<Keypoint>,
+}
+
+/// Struct representing the context payload data of a V7 annotation suitable for importing back into a V7 dataset item
+/// Identifies the slot names of the dataset item to import the annotation into
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AnnotationContext {
+    /// List of slot IDs in the dataset item in V7 to attach the annotations to
+    /// Although this field is called slot names, V7 actually expects slot IDs to be provided
+    pub slot_names: Vec<String>,
+}
+
+/// Struct representing an annotation payload data of a V7 annotation suitable for importing back into a V7 dataset item
+/// One instance of this struct corresponds to one annotation being imported into the dataset item
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AnnotationImportAnnotation {
+    pub id: String,
+    pub data: AnnotationImportData,
+    pub annotation_class_id: u32,
+    pub context_keys: AnnotationContext,
+}
+
+/// Struct representing a complete annotation import payload of V7 annotations into a single V7 dataset item
+/// There will be one instance of this struct for each dataset item, where each struct contains many items for the annotations its importing
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AnnotationImport {
+    pub annotations: Vec<AnnotationImportAnnotation>,
+    pub overwrite: bool,
+}
+
+impl From<Vec<Keypoint>> for AnnotationImportPolygon {
+    fn from(value: Vec<Keypoint>) -> Self {
+        AnnotationImportPolygon { path: value }
+    }
+}
+
+impl From<Vec<Keypoint>> for AnnotationImportData {
+    fn from(value: Vec<Keypoint>) -> Self {
+        AnnotationImportData {
+            polygon: Some(AnnotationImportPolygon::from(value)),
+            tag: None,
+        }
+    }
+}
+
+fn _find_annotation_class_id(
+    eligible_annotation_classes: &[&AnnotationClass],
+    class_name: &str,
+) -> Result<u32> {
+    eligible_annotation_classes
+        .iter()
+        .find(|ac| {
+            if ac.name.is_some() {
+                ac.name.clone().unwrap() == class_name
+            } else {
+                false
+            }
+        })
+        .context("Unable to find matching annotation class ID from export JSON")?
+        .id
+        .context("Annotation Class has no ID")
+}
+
+impl AnnotationImportAnnotation {
+    fn new_polygon_annotation(
+        original_annotation: &ImageAnnotation,
+        path: Vec<Keypoint>,
+        eligible_annotation_classes: &[&AnnotationClass],
+        slot_name: &str,
+    ) -> Result<Self> {
+        Ok(AnnotationImportAnnotation {
+            id: uuid::Uuid::new_v4().to_string(),
+            data: AnnotationImportData::from(path),
+            annotation_class_id: _find_annotation_class_id(
+                eligible_annotation_classes,
+                &original_annotation.name,
+            )?,
+            context_keys: AnnotationContext {
+                slot_names: vec![slot_name.to_string()],
+            },
+        })
+    }
+
+    fn new_tag_annotation(
+        original_annotation: &ImageAnnotation,
+        eligible_annotation_classes: &[&AnnotationClass],
+        slot_name: &str,
+    ) -> Result<Self> {
+        Ok(AnnotationImportAnnotation {
+            id: uuid::Uuid::new_v4().to_string(),
+            data: AnnotationImportData {
+                polygon: None,
+                tag: original_annotation.tag.clone(),
+            },
+            annotation_class_id: _find_annotation_class_id(
+                eligible_annotation_classes,
+                &original_annotation.name,
+            )?,
+            context_keys: AnnotationContext {
+                slot_names: vec![slot_name.to_string()],
+            },
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod config;
 pub mod datasets;
 pub mod export;
 pub mod filter;
+pub mod imports;
 pub mod item;
 pub mod team;
 pub mod utils;


### PR DESCRIPTION
## 🕵️ For the Reviewer

In this repo, we strive to follow the [conventional comments](https://conventionalcomments.org/) guidebook for providing feedback on PRs. Please adhere to this guidebook for a more efficient review process.

## 🔗 Related Tasks

This PR addresses part of [FRADATA-543](https://franklin-ai.atlassian.net/browse/FRADATA-543) - Migrate annotation imports to `darwin-v7`.

## 🚦 Depends on

There are no dependencies on other PRs for this update.

## 🛠️ What

Implemented the `import_annotation` method in the `darwin-v7` crate. This method encapsulates the functionality for importing annotations into datasets, previously done through manual V7 endpoint calls.

## 🤔 Why

The integration of the `import_annotation` method into the `darwin-v7` crate centralizes dataset management functionalities, enhancing code maintainability and consistency. This update is a step towards improving our internal data handling processes, ensuring that all dataset-related operations are streamlined and accessible within the `darwin-v7` crate.

## ⚠️ Concerns

## 📝 Notes

- This PR focuses solely on updating the `darwin-v7` repository. A separate PR will be created for updating the usage of this new function in other parts of our codebase.

[FRADATA-543]: https://franklin-ai.atlassian.net/browse/FRADATA-543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ