### PR TITLE
fix: derive eq method to compare list of keypoints

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -36,7 +36,7 @@ pub struct Polygon {
     pub paths: Vec<Vec<Keypoint>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default, PartialEq, PartialOrd)]
 pub struct Keypoint {
     // The horizontal coordinate of the keypoint
     pub x: f32,


### PR DESCRIPTION
## For the Reviewer

In this repo, we try to follow the [conventional comments](https://conventionalcomments.org/) guidebook when providing feedback to PRs. Please follow the guidebook, to make reviewing a smoother experience for you and me!



## What

Updates the Keypoint structure to implement PartialEq and PartialOrd so as to be able to compare linestrings( list of keypoints) against each other

