### PR TITLE
Color should be an Option as it is not always present and add support for a new field called raster_layer

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -12,7 +12,7 @@ use crate::expect_http_ok;
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq, Default)]
 pub struct AnnotationClassMetadata {
     #[serde(rename = "_color")]
-    pub color: String,
+    pub color: Option<String>,
     pub polygon: Option<HashMap<String, String>>, // TODO find out what this type actually is
     pub auto_annotate: Option<HashMap<String, String>>, // TODO find out what this type actually is
     pub inference: Option<HashMap<String, String>>, // TODO find out what this type actually is
@@ -76,11 +76,12 @@ pub enum AnnotationType {
     Measures,
     #[strum(serialize = "polygon")]
     Polygon(Polygon),
-
     Skeleton,
     #[strum(serialize = "tag")]
     Tag(Tag),
     Text(Text),
+    #[serde(rename = "raster_layer")]
+    RasterLayer,
 }
 
 // Various ids for annotation types and sub types
@@ -122,6 +123,7 @@ impl From<AnnotationType> for u32 {
             AnnotationType::Skeleton => 12,
             AnnotationType::Tag(_) => 1,
             AnnotationType::Text(_) => 6,
+            AnnotationType::RasterLayer => todo!(),
         }
     }
 }


### PR DESCRIPTION
-------

## For the Reviewer

In this repo, we try to follow the [conventional comments](https://conventionalcomments.org/) guidebook when providing feedback to PRs. Please follow the guidebook, to make reviewing a smoother experience for you and me!

## Related Tasks


## Depends on


## What

Color should be an option as it is not always present, and add support for a new field called raster_layer.

## Why

V7 annotation class has a new field, and the `_color` field is not always present, so we made it optional.

## Concerns

This section is optional, however if you have any concerns or questions regarding aspects of the PR, they can be included here. Including the concerns in this section ensures that they can be discussed as a part of the PR review.

## Notes
This section is also optional and should include anything else that you would like to discuss in the PR review that is not captured elsewhere.