### PR TITLE
chore: Wrap API Response Properties in `Option<>` for `workflow` Client Calls in darwin-v7 #FRADATA-609

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -22,13 +22,13 @@ pub struct AnnotationClassMetadata {
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]
 pub struct BoundingBox {
     // Height of the bounding box
-    pub h: f32,
+    pub h: Option<f32>,
     // Width of the bounding box
-    pub w: f32,
+    pub w: Option<f32>,
     // Left-most coordinate of the bounding box
-    pub x: f32,
+    pub x: Option<f32>,
     // Top-most coordinate of the bounding box
-    pub y: f32,
+    pub y: Option<f32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, Default)]

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -847,7 +847,7 @@ where
                     .dataset
                     .as_ref()
                     .expect("No associated dataset to workflow");
-                dataset.name == *dataset_name
+                dataset.name.as_ref() == Some(dataset_name)
             })
             .collect::<Vec<_>>()
             .first()

--- a/src/item.rs
+++ b/src/item.rs
@@ -723,7 +723,7 @@ mod test_serde {
         assert_eq!(ser_item.status, DatasetItemStatus::New);
         assert_eq!(ser_item.dataset_id, 657106);
         assert_eq!(ser_item.slots.len(), 1);
-        let levels = &ser_item.slots.get(0).unwrap().metadata.levels;
+        let levels = &ser_item.slots.first().unwrap().metadata.levels;
         assert_eq!(levels.len(), 8);
         assert_eq!(levels.get(&0).unwrap().format, "png".to_string());
     }


### PR DESCRIPTION
##  [🛠️ Refactor] Wrap API Response Properties in `Option<>` for `workflow` Client Calls in darwin-v7

## For the Reviewer

📚 **Please review according to the [conventional comments](https://conventionalcomments.org/) guidebook. Your feedback is vital for maintaining our code quality and team understanding.**

---

## Related Tasks

---

## Depends on

---

## What

🔨 **Changes Made:**
- Updated return types of `workflow` client functions in darwin-v7 to use `Option<>` for all API response properties.
- Modified functions in `WorkflowMethods` trait and `Workflow` struct to handle optional values accordingly.
- Implemented double-option pattern (`Vec<Option<T>>`) for lists that could contain `null` values.

---

## Why

🎯 **Purpose & Context:**
- Our experience with the V7 API has shown that response types are not always consistent with documentation, leading to potential runtime errors.
- By wrapping API response properties in `Option<>`, we pass the responsibility of value existence checks downstream, enhancing system stability.
- This change aligns with our tactical goal of improving fault tolerance in the `workflow` client calls.

---

## Concerns

---

## Notes

📝 *Additional Notes:*
- The PR focuses on a subset of a larger task to incrementally introduce changes without overwhelming system integration.
- Further refactoring for other client calls will follow based on the feedback and results from this PR.

---

📝 **Quick Note on `fra-datalake` Integration, Branching Strategy, and Expected Changes:**

This PR introduces crucial changes to the `workflow` client in `darwin-v7`, impacting how `fra-datalake` interacts with our library. To ensure smooth integration and minimize disruptions, we're adopting a detailed branching and integration approach:

1. **Individual Feature Branches:** Each area of change (annotations, comments, datasets, team) will be developed in its own dedicated branch. This ensures focused development and testing for each specific feature.

2. **Merging into `chore/FRA-609-option-responses`:** Upon completion and review, each feature branch will be merged into `chore/FRA-609-option-responses` through a PR. This step allows us to consolidate changes and conduct integrated testing.

3. **Controlled Testing:** `fra-datalake` will then use the `chore/FRA-609-option-responses` branch for testing, enabling us to identify and address issues in a controlled environment.

4. **Final Integration:** After thorough testing and refinements, we'll merge the consolidated changes from `chore/FRA-609-option-responses` into the main branch, ensuring stability across all systems.

**JIRA Ticket for Integration:**
The integration of `fra-datalake` with these changes is tracked under JIRA ticket [FRADATA-613](https://franklin-ai.atlassian.net/browse/FRADATA-613).

**Expected Changes in Individual Branches:**

- **Annotations Branch:** Enhancements in annotation data handling.
- **Comments Branch:** Improved management and processing of comments.
- **Datasets Branch:** Upgrades to dataset handling for better reliability.
- **Team Branch:** Enhancements in team management functionalities.



[FRADATA-613]: https://franklin-ai.atlassian.net/browse/FRADATA-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ