### PR TITLE
chore: Refactor annotations response as options #FRADATA-609

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -156,7 +156,7 @@ impl AnnotationType {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
 pub struct AnnotationDataset {
-    pub id: u32,
+    pub id: Option<u32>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy)]
@@ -165,16 +165,16 @@ pub struct AnnotationClass {
     pub annotation_class_image_url: Option<String>,
 
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub annotation_types: Vec<String>,
+    pub annotation_types: Vec<Option<String>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotation_type_ids: Option<Vec<u32>>,
+    pub annotation_type_ids: Option<Vec<Option<u32>>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dataset_id: Option<u32>,
 
     // #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub datasets: Vec<AnnotationDataset>,
+    pub datasets: Vec<Option<AnnotationDataset>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<u32>,
@@ -186,7 +186,7 @@ pub struct AnnotationClass {
     pub description: Option<String>,
 
     // #[serde(skip_serializing_if = "Option::is_none")]
-    pub images: Vec<String>, // TODO: find out what this type is
+    pub images: Vec<Option<String>>, // TODO: find out what this type is
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inserted_at: Option<String>,


### PR DESCRIPTION
## [🛠️ Refactor] Enhance Annotations Response Handling in `darwin-v7`

## For the Reviewer

📚 **Please review this PR according to the [conventional comments](https://conventionalcomments.org/) guide.**

---

## Related Tasks

---

## Depends on

---

## What

🔨 **Annotation Response Refactor:**
- Refactored annotation response handling in `darwin-v7` to encapsulate all properties within `Option<>`.
- Adjusted methods in `AnnotationsClass` struct to use optional values.
- Introduced a pattern of `Vec<Option<T>>` for annotation lists, accommodating potential `null` values in the responses.

---

## Why

🎯 **Rationale & Context:**
- Inconsistencies in annotation responses from the V7 API have been observed, sometimes diverging from the documented types.
- Utilizing `Option<>` for annotation properties ensures more robust error handling and system resilience by explicitly managing the presence or absence of data.
- This refactor is a strategic move towards enhancing the reliability of our annotation processing within the `workflow` client.

---

## Concerns

---

## Notes

📝 **Additional Context:**
- This PR is part of a broader initiative to incrementally improve our system's robustness, focusing initially on annotation responses.
- Based on the outcomes and feedback from this update, similar enhancements for other response types (comments, datasets, team management) are planned.

---

📝 **Integration with `fra-datalake` and Branch Strategy:**

This specific refactor is a critical part of ensuring that `fra-datalake` effectively integrates with the latest updates in `darwin-v7`. Our approach:

1. **Dedicated Feature Branch:** Development and initial testing of annotation response enhancements are conducted in a separate feature branch.

2. **Merge into `chore/FRA-609-option-responses`:** After review and testing, this branch will be merged into `chore/FRA-609-option-responses` via a PR.

3. **Testing with `fra-datalake`:** Using the `chore/FRA-609-option-responses` branch, `fra-datalake` will undergo testing with these new changes.

4. **Final Integration:** Post-testing, and based on successful outcomes, we'll merge these changes into the main branch, ensuring annotation response handling enhancements are propagated system-wide.

**Tracking via JIRA Ticket:**
Integration progress with `fra-datalake` are managed under [FRADATA-613](https://franklin-ai.atlassian.net/browse/FRADATA-613).


[FRADATA-613]: https://franklin-ai.atlassian.net/browse/FRADATA-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ