### PR TITLE
Chore/fra 609 comment optional

### DIFF
--- a/src/comment.rs
+++ b/src/comment.rs
@@ -36,34 +36,34 @@ where
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
 pub struct CommentLine {
-    pub author_id: u32,
-    pub body: String,
-    pub comment_thread_id: String,
-    pub created_by_system: bool,
-    pub id: String,
-    pub inserted_at: String,
-    pub updated_at: String,
+    pub author_id: Option<u32>,
+    pub body: Option<String>,
+    pub comment_thread_id: Option<String>,
+    pub created_by_system: Option<bool>,
+    pub id: Option<String>,
+    pub inserted_at: Option<String>,
+    pub updated_at: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
 pub struct CommentThreadResponse {
-    pub author_id: u32,
-    pub bounding_box: BoundingBox,
-    pub comment_count: u32,
-    pub dataset_item_id: String,
-    pub first_comment: CommentLine,
-    pub id: String,
-    pub inserted_at: String,
+    pub author_id: Option<u32>,
+    pub bounding_box: Option<BoundingBox>,
+    pub comment_count: Option<u32>,
+    pub dataset_item_id: Option<String>,
+    pub first_comment: Option<CommentLine>,
+    pub id: Option<String>,
+    pub inserted_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub issue_data: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub issue_types: Option<String>,
-    pub last_comment_at: String,
-    pub resolved: bool,
+    pub last_comment_at: Option<String>,
+    pub resolved: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub section_index: Option<String>,
-    pub slot_name: String,
-    pub updated_at: String,
+    pub slot_name: Option<String>,
+    pub updated_at: Option<String>,
 }
 
 #[async_trait]


### PR DESCRIPTION
## [🛠️ Refactor] Update `CommentThreadResponse` in `darwin-v7` to Use Optional Types

### For the Reviewer

📚 **Please review this PR according to the [conventional comments](https://conventionalcomments.org/) guide.**

---

### Related Tasks

---

### Depends on

---

### What

🔨 **Enhancements in `CommentThreadResponse` Handling:**
- Updated `CommentThreadResponse` in the `CommentMethods` trait to use `Option<>` for all response properties.
- Ensured all base values (e.g., `String`) are now wrapped as `Option<String>`.
- Struct values (e.g., `Annotator`) are encapsulated as `Option<Annotator>`.
- For collections like `Vec<String>`, implemented a double-optional pattern (`Vec<Option<String>>`) to handle cases where either the collection or its elements might be null.

---

### Why

🎯 **Rationale & Context:**
- Past reliance on static types from the V7 API led to issues due to occasional mismatches with the API's documentation.
- Implementing `Option<>` for all API response properties in `darwin-v7` transfers the responsibility of value verification to the consumer, enhancing error handling.
- This approach reduces the likelihood of API call failures due to missing/incorrect properties, thereby improving overall system stability.

---

### Concerns

---

### Notes

📝 **Additional Context:**
- This change is a tactical move to address the discrepancies observed in API responses, ensuring more robust interaction with the V7 API.
- By wrapping every potential value from the API responses in `Option<>`, we provide more flexibility and reliability in our system's response handling mechanism.

---

### Integration with `fra-datalake` and Branch Strategy:

Post-review, this PR will be merged into the `chore/FRA-609-option-responses` branch. This integration is key for ensuring that `fra-datalake` aligns with the latest improvements in handling optional types within `darwin-v7`.
