### PR TITLE
Chore:  datasets optional #FRADATA-609

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,7 @@ dependencies = [
  "deunicode",
  "dummy",
  "rand 0.8.5",
+ "rand_core 0.6.4",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Unofficial rust client for the [V7 annotation platform](https://d
 
 [dependencies]
 anyhow = "1.0"
-fake = { version = "2.9", features = ["derive", "uuid"] }
+fake = { version = "2.9", features = ["derive", "uuid", "always-true-rng"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -2,7 +2,7 @@ use crate::classes::BoundingBox;
 use crate::client::V7Methods;
 use crate::expect_http_ok;
 use crate::item::DatasetItemV2;
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 #[allow(unused_imports)]
 use fake::{Dummy, Fake};
@@ -79,7 +79,11 @@ where
     ) -> Result<CommentThreadResponse> {
         let response = client
             .post(
-                &format!("v2/teams/{}/items/{}/comment_threads", team_slug, self.id),
+                &format!(
+                    "v2/teams/{}/items/{}/comment_threads",
+                    team_slug,
+                    self.id.as_ref().context("Dataset has no Id")?
+                ),
                 &data,
             )
             .await?;

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -12,8 +12,6 @@ use crate::workflow::{WorkflowBuilder, WorkflowMethods, WorkflowTemplate, Workfl
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use csv_async::AsyncReaderBuilder;
-#[allow(unused_imports)]
-use fake::{Dummy, Fake};
 use futures::io::Cursor;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -21,12 +19,17 @@ use std::cmp::PartialEq;
 use std::collections::HashMap;
 use std::fmt::Display;
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[cfg(test)]
+use fake::Dummy;
+
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AnnotationHotKeys {
     pub key: String,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Dataset {
     pub active: Option<bool>,
     pub archived: Option<bool>,
@@ -40,11 +43,11 @@ pub struct Dataset {
 
     // TODO: annotations
     #[serde(skip)]
-    pub annotation_classes: Vec<String>,
+    pub annotation_classes: Vec<Option<String>>,
 
     pub default_workflow_template_id: Option<u32>,
 
-    pub id: u32,
+    pub id: Option<u32>,
     pub inserted_at: Option<String>,
     pub instructions: Option<String>,
 
@@ -62,20 +65,21 @@ pub struct Dataset {
     pub progress: Option<f64>,
     pub public: Option<bool>,
     pub reviewers_can_annotate: Option<bool>,
-    pub slug: String,
+    pub slug: Option<String>,
     pub team_id: Option<u32>,
     pub team_slug: Option<String>,
 
     // TODO: thumbnails
     #[serde(skip)]
-    pub thumbnails: Option<Vec<String>>,
+    pub thumbnails: Vec<Option<String>>,
     pub updated_at: Option<String>,
     pub version: Option<u32>,
     pub work_size: Option<u32>,
     pub work_prioritization: Option<String>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct DatasetUpdate {
     pub annotation_hotkeys: Option<HashMap<String, String>>,
     pub annotators_can_create_tags: Option<bool>,
@@ -108,25 +112,29 @@ impl From<&Dataset> for DatasetUpdate {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct ExportMetadata {
-    pub annotation_classes: Vec<AnnotationClass>,
-    pub annotation_types: Vec<TypeCount>,
+    pub annotation_classes: Vec<Option<AnnotationClass>>,
+    pub annotation_types: Vec<Option<TypeCount>>,
 }
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy)]
+
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Export {
-    pub name: String,
+    pub name: Option<String>,
     pub download_url: Option<String>,
-    pub format: ExportFormat,
-    pub inserted_at: String,
-    pub latest: bool,
+    pub format: Option<ExportFormat>,
+    pub inserted_at: Option<String>,
+    pub latest: Option<bool>,
     #[serde(skip_deserializing)]
     pub metadata: ExportMetadata,
     pub status: Option<String>,
-    pub version: u16,
+    pub version: Option<u16>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ExportFormat {
     #[default]
@@ -159,19 +167,21 @@ impl From<ExportFormat> for &str {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct DatasetName {
     pub name: String,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct AddDataItemsPayload {
     pub items: Vec<AddDataPayload>,
     pub storage_name: String,
 }
 
 /// Version 2.0 equivalent of `AddDataItemsPayload`
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+///
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RegisterExistingItemPayload {
     /// Slug name of the Dataset to upload images to
     pub dataset_slug: String,
@@ -181,24 +191,28 @@ pub struct RegisterExistingItemPayload {
     pub items: Vec<ExistingSimpleItem>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResponseItem {
-    pub dataset_item_id: u64,
-    pub filename: String,
+    pub dataset_item_id: Option<u64>,
+    pub filename: Option<String>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ArchiveResponseItems {
-    pub affected_item_count: i32,
+    pub affected_item_count: Option<i32>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AddDataItemsResponse {
-    pub blocked_items: Vec<ResponseItem>,
-    pub items: Vec<ResponseItem>,
+    pub blocked_items: Vec<Option<ResponseItem>>,
+    pub items: Vec<Option<ResponseItem>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SlotResponse {
     pub as_frames: bool,
     pub extract_views: bool,
@@ -212,26 +226,30 @@ pub struct SlotResponse {
     pub item_type: DatasetItemTypes,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RegistrationResponseItem {
-    pub id: String,
-    pub name: String,
-    pub path: String,
-    pub slots: Vec<SlotResponse>,
+    pub id: Option<String>,
+    pub name: Option<String>,
+    pub path: Option<String>,
+    pub slots: Vec<Option<SlotResponse>>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RegisterExistingItemResponse {
-    pub blocked_items: Vec<RegistrationResponseItem>,
-    pub items: Vec<RegistrationResponseItem>,
+    pub blocked_items: Vec<Option<RegistrationResponseItem>>,
+    pub items: Vec<Option<RegistrationResponseItem>>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct ArchiveItemPayload {
     pub filters: Filter,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 struct AssignItemPayload {
     pub assignee_id: u32,
     pub filter: Filter,
@@ -275,10 +293,11 @@ pub struct SetStagePayloadV2 {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SetStageResponse {
-    pub created_commands: u32,
+    pub created_commands: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
+#[cfg_attr(test, derive(Dummy))]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ItemReport {
     /// Original filename of the item
     pub filename: Option<String>,
@@ -419,7 +438,7 @@ where
         include_export_token: bool,
         filter: Option<&Filter>,
     ) -> Result<()>;
-    async fn list_exports(&self, client: &C) -> Result<Vec<Export>>;
+    async fn list_exports(&self, client: &C) -> Result<Vec<Option<Export>>>;
 }
 
 #[async_trait]
@@ -427,9 +446,9 @@ pub trait DatasetDescribeMethods<C>
 where
     C: V7Methods,
 {
-    async fn list_datasets(client: &C) -> Result<Vec<Dataset>>;
+    async fn list_datasets(client: &C) -> Result<Vec<Option<Dataset>>>;
     #[deprecated = "V2 of the V7 API requires use of `list_dataset_items_v2`"]
-    async fn list_dataset_items(&self, client: &C) -> Result<Vec<DatasetItem>>;
+    async fn list_dataset_items(&self, client: &C) -> Result<Vec<Option<DatasetItem>>>;
     async fn list_dataset_items_v2(&self, client: &C) -> Result<Item>;
     async fn show_dataset(client: &C, id: &u32) -> Result<Dataset>;
 }
@@ -507,7 +526,10 @@ where
 
     async fn archive_dataset(&self, client: &C) -> Result<Dataset> {
         let response = client
-            .put::<String>(&format!("datasets/{}/archive", &self.id), None)
+            .put::<String>(
+                &format!("datasets/{}/archive", &self.id.context("Id required")?),
+                None,
+            )
             .await?;
 
         expect_http_ok!(response, Dataset)
@@ -526,7 +548,10 @@ where
         };
 
         let response = client
-            .post(&format!("datasets/{}/assign_items", self.id), &payload)
+            .post(
+                &format!("datasets/{}/assign_items", self.id.context("Id required")?),
+                &payload,
+            )
             .await?;
 
         let status = response.status();
@@ -546,7 +571,10 @@ where
                                          // so we have to replicate the rest of the existing settings
 
         let response = client
-            .put(&format!("datasets/{}", self.id), Some(&payload))
+            .put(
+                &format!("datasets/{}", self.id.context("Id required")?),
+                Some(&payload),
+            )
             .await?;
         let status = response.status();
 
@@ -573,7 +601,7 @@ where
             self.team_slug
                 .as_ref()
                 .context("Dataset is missing team slug")?,
-            self.slug
+            self.slug.as_ref().context("Dataset is missing slug")?
         );
 
         let response = client.put(&endpoint, Some(&api_payload)).await?;
@@ -589,7 +617,11 @@ where
         external_storage_slug: String,
     ) -> Result<RegisterExistingItemResponse> {
         let api_payload = RegisterExistingItemPayload {
-            dataset_slug: self.slug.to_string(),
+            dataset_slug: self
+                .slug
+                .as_ref()
+                .context("Dataset is missing slug")?
+                .to_string(),
             storage_slug: external_storage_slug,
             items: data,
         };
@@ -612,7 +644,10 @@ where
         let mut payload = DatasetUpdate::from(self);
         payload.annotation_hotkeys = Some(hotkeys);
         let response = client
-            .put(&format!("datasets/{}", self.id), Some(&payload))
+            .put(
+                &format!("datasets/{}", self.id.context("Dataset is missing Id")?),
+                Some(&payload),
+            )
             .await?;
         let status = response.status();
         if status != 200 {
@@ -643,7 +678,7 @@ where
         let endpoint = format!(
             "v2/teams/{team_slug}/items/{item_id}/import",
             team_slug = self.team_slug.as_ref().with_context(|| format!(
-                "Dataset is missing team slug. dataset slug: {}",
+                "Dataset is missing team slug. dataset slug: {:?}",
                 self.slug
             ))?
         );
@@ -673,7 +708,7 @@ where
         let endpoint = format!(
             "v2/teams/{}/datasets/{}/exports",
             self.team_slug.as_ref().context("Missing team slug")?,
-            self.slug
+            self.slug.as_ref().context("Dataset is missing slug")?
         );
 
         let payload = GenerateExportPayload {
@@ -697,16 +732,16 @@ where
         Ok(())
     }
 
-    async fn list_exports(&self, client: &C) -> Result<Vec<Export>> {
+    async fn list_exports(&self, client: &C) -> Result<Vec<Option<Export>>> {
         let endpoint = format!(
             "v2/teams/{}/datasets/{}/exports",
             self.team_slug.as_ref().context("Missing team slug")?,
-            self.slug
+            self.slug.as_ref().context("Dataset is missing slug")?
         );
 
         let response = client.get(&endpoint).await?;
 
-        expect_http_ok!(response, Vec<Export>)
+        expect_http_ok!(response, Vec<Option<Export>>)
     }
 }
 
@@ -715,16 +750,21 @@ impl<C> DatasetDescribeMethods<C> for Dataset
 where
     C: V7Methods + std::marker::Sync,
 {
-    async fn list_datasets(client: &C) -> Result<Vec<Dataset>> {
+    async fn list_datasets(client: &C) -> Result<Vec<Option<Dataset>>> {
         let response = client.get("datasets").await?;
 
-        expect_http_ok!(response, Vec<Dataset>)
+        expect_http_ok!(response, Vec<Option<Dataset>>)
     }
 
-    async fn list_dataset_items(&self, client: &C) -> Result<Vec<DatasetItem>> {
-        let response = client.get(&format!("datasets/{}/items", self.id)).await?;
+    async fn list_dataset_items(&self, client: &C) -> Result<Vec<Option<DatasetItem>>> {
+        let response = client
+            .get(&format!(
+                "datasets/{}/items",
+                self.id.context("Dataset is missing Id")?
+            ))
+            .await?;
 
-        expect_http_ok!(response, Vec<DatasetItem>)
+        expect_http_ok!(response, Vec<Option<DatasetItem>>)
     }
 
     async fn list_dataset_items_v2(&self, client: &C) -> Result<Item> {
@@ -732,7 +772,7 @@ where
             .get(&format!(
                 "v2/teams/{}/items?dataset_ids={}",
                 self.team_slug.as_ref().context("Missing team slug")?,
-                self.id
+                self.id.context("Dataset is missing Id")?
             ))
             .await?;
 
@@ -758,7 +798,10 @@ where
 
         let response = client
             .put(
-                &format!("datasets/{}/items/move_to_new", self.id),
+                &format!(
+                    "datasets/{}/items/move_to_new",
+                    self.id.context("Dataset missing Id")?
+                ),
                 Some(&payload),
             )
             .await?;
@@ -780,7 +823,10 @@ where
         };
 
         let response = client
-            .put(&format!("datasets/{}/set_stage", self.id), Some(&payload))
+            .put(
+                &format!("datasets/{}/set_stage", self.id.context("Data missing Id")?),
+                Some(&payload),
+            )
             .await?;
 
         let status = response.status();
@@ -800,7 +846,10 @@ where
     ) -> Result<WorkflowTemplate> {
         let response = client
             .post(
-                &format!("datasets/{}/workflow_templates", self.id),
+                &format!(
+                    "datasets/{}/workflow_templates",
+                    self.id.context("Dataset is missing Id")?
+                ),
                 workflow,
             )
             .await?;
@@ -828,7 +877,8 @@ where
 
         let endpoint = format!(
             "datasets/{}/default_workflow_template/{}",
-            self.id, workflow_id
+            self.id.context("Dataset is missing Id")?,
+            workflow_id
         );
         let payload: Option<&WorkflowTemplate> = None;
         let response = client.put(&endpoint, payload).await?;
@@ -863,7 +913,7 @@ where
     ) -> Result<SetStageResponse> {
         let filters = if filters.is_none() {
             SetStageFilter {
-                dataset_ids: vec![self.id],
+                dataset_ids: vec![self.id.context("Dataset missing Id")?],
                 select_all: true,
                 workflow_stage_ids: None,
             }
@@ -892,7 +942,7 @@ where
         let endpoint = format!(
             "teams/{}/datasets/{}/item_reports",
             self.team_slug.as_ref().context("Missing team slug")?,
-            self.slug
+            self.slug.as_ref().context("Dataset missing slug")?
         );
         let response = client.get(&endpoint).await?;
         let status = response.status();
@@ -909,7 +959,7 @@ impl Display for Dataset {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}:{}/{}",
+            "{:?}:{}/{:?}",
             self.id,
             self.team_slug.as_ref().unwrap_or(&"team-slug".to_string()),
             self.slug
@@ -924,6 +974,10 @@ mod test_client_calls {
     use crate::client::V7Client;
 
     use fake::{Fake, Faker};
+
+    // Utilizing Faker with an AlwaysTrueRng to guarantee that all Option types are populated with Some values
+    // This ensures consistent data generation where no field is left as None
+    use fake::utils::AlwaysTrueRng;
     use serde_json::json;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -938,7 +992,7 @@ mod test_client_calls {
             "api-key".to_string(),
             "some-team".to_string(),
         )
-        .unwrap();
+        .expect("Failed to get V7Client");
 
         Mock::given(method("GET"))
             .and(path("/datasets"))
@@ -946,13 +1000,24 @@ mod test_client_calls {
             .mount(&mock_server)
             .await;
 
-        let datasets = Dataset::list_datasets(&client).await.unwrap();
+        let datasets = Dataset::list_datasets(&client)
+            .await
+            .expect("Failed to list datasets");
 
         // Pick a few values to avoid f64 comparison issues
         assert_eq!(datasets.len(), mock_data.len());
-        assert_eq!(datasets[0].id, mock_data[0].id);
-        assert_eq!(datasets[0].slug, mock_data[0].slug);
-        assert_eq!(datasets[1].inserted_at, mock_data[1].inserted_at);
+        assert_eq!(
+            datasets[0].as_ref().expect("Expected dataset").id,
+            mock_data[0].id
+        );
+        assert_eq!(
+            datasets[0].as_ref().expect("Expected dataset").slug,
+            mock_data[0].slug
+        );
+        assert_eq!(
+            datasets[1].as_ref().expect("Expected dataset").inserted_at,
+            mock_data[1].inserted_at
+        );
     }
 
     #[tokio::test]
@@ -969,7 +1034,7 @@ mod test_client_calls {
             "api-key".to_string(),
             "some-team".to_string(),
         )
-        .unwrap();
+        .expect("Failed to get V7Client");
 
         Dataset::list_datasets(&client)
             .await
@@ -990,7 +1055,7 @@ mod test_client_calls {
             "api-key".to_string(),
             "some-team".to_string(),
         )
-        .unwrap();
+        .expect("Failed to get V7Client");
 
         Dataset::list_datasets(&client)
             .await
@@ -1000,8 +1065,10 @@ mod test_client_calls {
     #[tokio::test]
     async fn test_list_dataset_items() {
         let mock_server = MockServer::start().await;
-        let mock_data: Dataset = Faker.fake();
-        let dset_id = mock_data.id;
+        let mut rng = AlwaysTrueRng::default();
+        let mock_data: Dataset = Faker.fake_with_rng(&mut rng);
+
+        let dset_id = mock_data.id.expect("Id must be set");
 
         // Just generate two random values for comparison
         let mock_result_vec: Vec<DatasetItem> = fake::vec![DatasetItem; 2];
@@ -1011,7 +1078,7 @@ mod test_client_calls {
             "api-key".to_string(),
             "some-team".to_string(),
         )
-        .unwrap();
+        .expect("Failed to get V7Client");
 
         Mock::given(method("GET"))
             .and(path(format!("/datasets/{dset_id}/items")))
@@ -1020,14 +1087,23 @@ mod test_client_calls {
             .await;
 
         #[allow(deprecated)]
-        let result: Vec<DatasetItem> = mock_data.list_dataset_items(&client).await.unwrap();
+        let result: Vec<Option<DatasetItem>> = mock_data
+            .list_dataset_items(&client)
+            .await
+            .expect("Failed to list dataset items");
 
         // Only compare a few values, this is mostly testing the endpoint
         // invocation and not serde.
         assert_eq!(result.len(), mock_result_vec.len());
-        assert_eq!(result[0].status, mock_result_vec[0].status);
         assert_eq!(
-            result[result.len() - 1].id,
+            result[0].as_ref().expect("Expected dataset").status,
+            mock_result_vec[0].status
+        );
+        assert_eq!(
+            result[result.len() - 1]
+                .as_ref()
+                .expect("Expected dataset")
+                .id,
             mock_result_vec[mock_result_vec.len() - 1].id
         );
     }
@@ -1035,11 +1111,12 @@ mod test_client_calls {
     #[tokio::test]
     async fn test_archive_dataset_items() {
         let mock_server = MockServer::start().await;
-        let mut mock_data: Dataset = Faker.fake();
+        let mut rng = AlwaysTrueRng::default();
+        let mut mock_data: Dataset = Faker.fake_with_rng(&mut rng);
         let team_slug = mock_data.id;
-        mock_data.team_slug = Some(team_slug.to_string());
+        mock_data.team_slug = team_slug.map(|s| s.to_string());
 
-        let dset_id: Option<Vec<u32>> = Some(vec![mock_data.id]);
+        let dset_id: Option<Vec<u32>> = Some(vec![mock_data.id.expect("Id must be set")]);
         let complete_status: Option<Vec<String>> = Some(vec!["Complete".to_string()]);
 
         let filter = Filter {
@@ -1053,26 +1130,34 @@ mod test_client_calls {
             "api-key".to_string(),
             "some-team".to_string(),
         )
-        .unwrap();
+        .expect("Failed to get V7Client");
 
         Mock::given(method("POST"))
-            .and(path(format!("v2/teams/{team_slug}/items/archive")))
+            .and(path(format!(
+                "v2/teams/{}/items/archive",
+                team_slug.expect("Team slug should be set")
+            )))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "affected_item_count": 1,
             })))
             .mount(&mock_server)
             .await;
 
-        let result = mock_data.archive_items(&client, &filter).await.unwrap();
+        let result = mock_data
+            .archive_items(&client, &filter)
+            .await
+            .expect("Failed to archive items");
 
-        assert_eq!(result.affected_item_count, 1);
+        assert_eq!(result.affected_item_count, Some(1));
     }
 
     #[tokio::test]
     async fn test_list_dataset_items_status_error() {
         let mock_server = MockServer::start().await;
-        let mock_data: Dataset = Faker.fake();
-        let dset_id = mock_data.id;
+
+        let mut rng = AlwaysTrueRng::default();
+        let mock_data: Dataset = Faker.fake_with_rng(&mut rng);
+        let dset_id = mock_data.id.expect("Id must be set");
 
         Mock::given(method("GET"))
             .and(path(format!("/datasets/{dset_id}/items")))
@@ -1085,7 +1170,7 @@ mod test_client_calls {
             "api-key".to_string(),
             "some-team".to_string(),
         )
-        .unwrap();
+        .expect("Failed to get V7 Client");
 
         #[allow(deprecated)]
         mock_data
@@ -1100,8 +1185,12 @@ mod test_client_calls {
         let mock_data = "filename,uploaded_date,status,workflow_start_date,workflow_complete_date,number_of_frames,folder,time_spent_annotating_sec,time_spent_reviewing_sec,automation_time_annotating_sec,automation_time_reviewing_sec,annotators,reviewers,was_rejected_in_review,url
 somefilename,2023-05-10 14:15:27,complete,2023-05-10 14:16:17,2023-05-17 01:28:13,,/,320,1,2,3,kevin@mail.com,,false,https://darwin.v7labs.com/workview?dataset=123456&image=789";
 
-        let mut dataset: Dataset = Faker.fake();
-        let dataset_slug = dataset.slug.clone();
+        let mut rng = AlwaysTrueRng::default();
+        let mut dataset: Dataset = Faker.fake_with_rng(&mut rng);
+        let dataset_slug = dataset
+            .slug
+            .clone()
+            .expect("Dataset slug should not be null");
         let team_slug = "some-team";
         dataset.team_slug = Some(team_slug.to_string());
 
@@ -1118,13 +1207,16 @@ somefilename,2023-05-10 14:15:27,complete,2023-05-10 14:16:17,2023-05-17 01:28:1
             "api-key".to_string(),
             "some-team".to_string(),
         )
-        .unwrap();
+        .expect("Failed to create V7 client");
 
-        let results = dataset.get_item_reports(&client).await.unwrap();
+        let results = dataset
+            .get_item_reports(&client)
+            .await
+            .expect("Failed to get item reports");
 
         assert_eq!(results.len(), 1);
 
-        let result = results.first().unwrap();
+        let result = results.first().expect("Get item reports had no result");
 
         assert_eq!(result.filename, Some("somefilename".to_string()));
     }
@@ -1172,10 +1264,12 @@ somefilename,2023-05-10 14:15:27,complete,2023-05-10 14:16:17,2023-05-17 01:28:1
             url
         ));
 
-        let results = item_reports_from_bytes(content.as_bytes()).await.unwrap();
+        let results = item_reports_from_bytes(content.as_bytes())
+            .await
+            .expect("Failed to get item reports from bytes");
         assert_eq!(results.len(), 1);
 
-        let result = results.first().unwrap();
+        let result = results.first().expect("Item report results were empty");
 
         assert_eq!(result.filename, Some(filename.to_string()));
         assert_eq!(result.uploaded_date, Some(uploaded_date.to_string()));

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -281,11 +281,11 @@ pub struct SetStageResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
 pub struct ItemReport {
     /// Original filename of the item
-    pub filename: String,
+    pub filename: Option<String>,
     /// Timestamp of when item was added to the dataset
-    pub uploaded_date: String,
+    pub uploaded_date: Option<String>,
     /// Current status of the dataset
-    pub status: DatasetItemStatus,
+    pub status: Option<DatasetItemStatus>,
     /// Timestamp of when item was first entered into a workflow
     pub workflow_start_date: Option<String>,
     /// Timestamp of when work on the item was completed. null if in progress
@@ -293,23 +293,23 @@ pub struct ItemReport {
     /// For playback videos, the number of frames in the video
     pub number_of_frames: Option<u32>,
     /// Path the item was assigned in the dataset
-    pub folder: String,
+    pub folder: Option<String>,
     /// Total duration of work perform by annotators
-    pub time_spent_annotating_sec: u64,
+    pub time_spent_annotating_sec: Option<u64>,
     /// Total duration of work perform by reviewers
-    pub time_spent_reviewing_sec: u64,
+    pub time_spent_reviewing_sec: Option<u64>,
     /// Total duration of automation actions performed in annotate stages
-    pub automation_time_annotating_sec: u64,
+    pub automation_time_annotating_sec: Option<u64>,
     /// Total duration of automation actions performed in review stages
-    pub automation_time_reviewing_sec: u64,
+    pub automation_time_reviewing_sec: Option<u64>,
     /// Emails of all annotators who performed work on this item, joined by semicolon
-    pub annotators: String,
+    pub annotators: Option<String>,
     /// Emails of all reviewers who performed work on this item, joined by semicolon
-    pub reviewers: String,
+    pub reviewers: Option<String>,
     /// True if item was every rejected in any review stage
-    pub was_rejected_in_review: bool,
+    pub was_rejected_in_review: Option<bool>,
     /// Darwin Workview URL for the item
-    pub url: String,
+    pub url: Option<String>,
 }
 
 pub async fn item_reports_from_bytes(contents: &[u8]) -> Result<Vec<ItemReport>> {
@@ -1126,7 +1126,7 @@ somefilename,2023-05-10 14:15:27,complete,2023-05-10 14:16:17,2023-05-17 01:28:1
 
         let result = results.first().unwrap();
 
-        assert_eq!(result.filename, "somefilename".to_string());
+        assert_eq!(result.filename, Some("somefilename".to_string()));
     }
 
     #[tokio::test]
@@ -1177,9 +1177,9 @@ somefilename,2023-05-10 14:15:27,complete,2023-05-10 14:16:17,2023-05-17 01:28:1
 
         let result = results.first().unwrap();
 
-        assert_eq!(result.filename, filename.to_string());
-        assert_eq!(result.uploaded_date, uploaded_date.to_string());
-        assert_eq!(result.status, DatasetItemStatus::Complete);
+        assert_eq!(result.filename, Some(filename.to_string()));
+        assert_eq!(result.uploaded_date, Some(uploaded_date.to_string()));
+        assert_eq!(result.status, Some(DatasetItemStatus::Complete));
         assert_eq!(
             result.workflow_start_date,
             Some(workflow_start_date.to_string())
@@ -1189,20 +1189,26 @@ somefilename,2023-05-10 14:15:27,complete,2023-05-10 14:16:17,2023-05-17 01:28:1
             Some(workflow_complete_date.to_string())
         );
         assert_eq!(result.number_of_frames, None);
-        assert_eq!(result.folder, folder.to_string());
-        assert_eq!(result.time_spent_annotating_sec, time_spent_annotating_sec);
-        assert_eq!(result.time_spent_reviewing_sec, time_spent_reviewing_sec);
+        assert_eq!(result.folder, Some(folder.to_string()));
+        assert_eq!(
+            result.time_spent_annotating_sec,
+            Some(time_spent_annotating_sec)
+        );
+        assert_eq!(
+            result.time_spent_reviewing_sec,
+            Some(time_spent_reviewing_sec)
+        );
         assert_eq!(
             result.automation_time_annotating_sec,
-            automation_time_annotating_sec
+            Some(automation_time_annotating_sec)
         );
         assert_eq!(
             result.automation_time_reviewing_sec,
-            automation_time_reviewing_sec
+            Some(automation_time_reviewing_sec)
         );
-        assert_eq!(result.annotators, annotators.to_string());
-        assert_eq!(result.reviewers, reviewers.to_string());
-        assert_eq!(result.was_rejected_in_review, was_rejected_in_review);
-        assert_eq!(result.url, url);
+        assert_eq!(result.annotators, Some(annotators.to_string()));
+        assert_eq!(result.reviewers, None);
+        assert_eq!(result.was_rejected_in_review, Some(was_rejected_in_review));
+        assert_eq!(result.url, Some(url.to_string()));
     }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -71,9 +71,9 @@ pub struct JsonExport {
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct Item {
-    pub name: String,
-    pub path: String,
-    pub source_info: SourceInfo,
+    pub name: Option<String>,
+    pub path: Option<String>,
+    pub source_info: Option<SourceInfo>,
     pub slots: Vec<Slot>,
 }
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -366,52 +366,52 @@ pub struct ItemSlotLevel {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
 pub struct ItemSlot {
-    pub file_name: String,
+    pub file_name: Option<String>,
     pub fps: Option<f32>,
-    pub id: String,
-    pub is_external: bool,
-    pub metadata: ItemSlotLevel,
-    pub size_bytes: u64,
-    pub slot_name: String,
-    pub streamable: bool,
-    pub total_sections: u32,
+    pub id: Option<String>,
+    pub is_external: Option<bool>,
+    pub metadata: Option<ItemSlotLevel>,
+    pub size_bytes: Option<u64>,
+    pub slot_name: Option<String>,
+    pub streamable: Option<bool>,
+    pub total_sections: Option<u32>,
     #[serde(rename = "type")]
-    pub item_slot_type: DatasetItemTypes,
-    pub upload_id: String,
+    pub item_slot_type: Option<DatasetItemTypes>,
+    pub upload_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
 pub struct DatasetItemLayout {
-    pub slots: Vec<String>,
+    pub slots: Vec<Option<String>>,
     #[serde(rename = "type")]
-    pub layout_type: String,
-    pub version: u32,
+    pub layout_type: Option<String>,
+    pub version: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
 pub struct DatasetItemV2 {
-    pub archived: bool,
-    pub cursor: String,
-    pub dataset_id: u32,
-    pub id: String,
+    pub archived: Option<bool>,
+    pub cursor: Option<String>,
+    pub dataset_id: Option<u32>,
+    pub id: Option<String>,
     pub inserted_at: Option<String>,
-    pub layout: DatasetItemLayout,
-    pub name: String,
+    pub layout: Option<DatasetItemLayout>,
+    pub name: Option<String>,
     pub path: Option<String>,
     pub priority: Option<u32>,
-    pub processing_status: DatasetItemStatus,
-    pub slot_types: Vec<DatasetItemTypes>,
-    pub slots: Vec<ItemSlot>,
-    pub status: DatasetItemStatus,
-    pub tags: Vec<String>,
+    pub processing_status: Option<DatasetItemStatus>,
+    pub slot_types: Vec<Option<DatasetItemTypes>>,
+    pub slots: Vec<Option<ItemSlot>>,
+    pub status: Option<DatasetItemStatus>,
+    pub tags: Vec<Option<String>>,
     pub updated_at: Option<String>,
-    pub uploads: Vec<String>,
-    pub workflow_status: StageType,
+    pub uploads: Vec<Option<String>>,
+    pub workflow_status: Option<StageType>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
 pub struct ItemPage {
-    pub count: u32,
+    pub count: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next: Option<String>,
     pub previous: Option<String>,
@@ -419,7 +419,7 @@ pub struct ItemPage {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
 pub struct Item {
-    pub items: Vec<DatasetItemV2>,
+    pub items: Vec<Option<DatasetItemV2>>,
     pub page: ItemPage,
 }
 
@@ -726,10 +726,20 @@ mod test_serde {
 
         let ser_item: DatasetItemV2 = serde_json::from_str(contents).unwrap();
 
-        assert_eq!(ser_item.status, DatasetItemStatus::New);
-        assert_eq!(ser_item.dataset_id, 657106);
+        assert_eq!(ser_item.status, Some(DatasetItemStatus::New));
+        assert_eq!(ser_item.dataset_id, Some(657106));
         assert_eq!(ser_item.slots.len(), 1);
-        let levels = &ser_item.slots.first().unwrap().metadata.levels;
+        let levels = &ser_item
+            .slots
+            .first()
+            .as_ref()
+            .expect("Expected at least one slot")
+            .as_ref()
+            .expect("Expected metadata")
+            .metadata
+            .as_ref()
+            .expect("Expected levels")
+            .levels;
         assert_eq!(levels.len(), 8);
         assert_eq!(levels.get(&0).unwrap().format, "png".to_string());
     }

--- a/src/item.rs
+++ b/src/item.rs
@@ -25,7 +25,7 @@ pub struct ImageLevel {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Levels {
     pub image_levels: HashMap<u32, ImageLevel>,
-    pub base_key: String,
+    pub base_key: Option<String>,
 }
 
 // JSON levels have a mix of ImageLevel information as well
@@ -104,7 +104,7 @@ impl<'de> Visitor<'de> for LevelVisitor {
 
         Ok(Levels {
             image_levels,
-            base_key,
+            base_key: Some(base_key),
         })
     }
 }
@@ -112,7 +112,7 @@ impl<'de> Visitor<'de> for LevelVisitor {
 impl Dummy<fake::Faker> for Levels {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
         let max_levels: u32 = (2..5).fake_with_rng(rng);
-        let base_key: String = Faker.fake_with_rng(rng);
+        let base_key: Option<String> = Faker.fake_with_rng(rng);
 
         let mut image_levels = HashMap::new();
         for lvl in 1..max_levels {
@@ -134,7 +134,7 @@ pub struct Image {
     pub format: Option<String>,
     pub height: Option<u32>,
     pub width: Option<u32>,
-    pub id: u32,
+    pub id: Option<u32>,
     pub key: Option<String>,
     pub levels: Option<Levels>,
     pub original_filename: Option<String>,
@@ -145,12 +145,12 @@ pub struct Image {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
 pub struct DatasetImage {
-    pub dataset_id: u32,
+    pub dataset_id: Option<u32>,
     pub dataset_video_id: Option<u32>,
-    pub id: u32,
-    pub image: Image,
-    pub seq: u32,
-    pub set: u32,
+    pub id: Option<u32>,
+    pub image: Option<Image>,
+    pub seq: Option<u32>,
+    pub set: Option<u32>,
 }
 
 // TODO: Define this struct
@@ -317,21 +317,21 @@ pub struct ExistingSimpleItem {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
 pub struct DatasetItem {
-    pub archived: bool,
+    pub archived: Option<bool>,
     pub archived_reason: Option<String>,
     pub current_workflow: Option<Workflow>,
     pub current_workflow_id: Option<u32>,
     pub dataset_id: Option<u32>,
-    pub dataset_image: DatasetImage,
+    pub dataset_image: Option<DatasetImage>,
     pub dataset_image_id: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dataset_video: Option<DatasetVideo>,
     pub dataset_video_id: Option<u32>,
     pub file_size: Option<u32>,
-    pub filename: String,
+    pub filename: Option<String>,
     pub height: Option<u32>,
     pub width: Option<u32>,
-    pub id: u32,
+    pub id: Option<u32>,
     pub inserted_at: Option<String>,
     pub updated_at: Option<String>,
     pub labels: Option<Vec<u32>>,
@@ -339,16 +339,16 @@ pub struct DatasetItem {
     pub priority: Option<u32>,
     pub seq: Option<u32>,
     pub set: Option<u32>,
-    pub status: DatasetItemStatus,
+    pub status: Option<DatasetItemStatus>,
     #[serde(rename = "type")]
-    pub item_type: DatasetItemTypes, // This can probably be an enum
+    pub item_type: Option<DatasetItemTypes>, // This can probably be an enum
 }
 
 impl Display for DatasetItem {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "{{id-{}}}:{}/{}[{}]",
+            "{{id-{:?}}}:{:?}/{:?}[{:?}]",
             self.id, self.filename, self.status, self.item_type
         )
     }
@@ -451,7 +451,7 @@ mod test_serde {
 
         let image_level: Levels = serde_json::from_str(contents).unwrap();
 
-        assert_eq!(image_level.base_key, "some-base-key.jpg".to_string());
+        assert_eq!(image_level.base_key, Some("some-base-key.jpg".to_string()));
         assert_eq!(
             image_level.image_levels.get(&0).unwrap().format,
             "png".to_string()
@@ -580,7 +580,7 @@ mod test_serde {
 
         let ser_item: DatasetItem = serde_json::from_str(contents).unwrap();
 
-        assert_eq!(ser_item.status, DatasetItemStatus::Complete);
+        assert_eq!(ser_item.status, Some(DatasetItemStatus::Complete));
         assert_eq!(ser_item.dataset_image_id, Some(646799980));
         assert_eq!(ser_item.labels.unwrap().len(), 3);
         assert!(ser_item
@@ -591,12 +591,18 @@ mod test_serde {
             .copied()
             .any(|x| x == 1));
 
-        let level_0 = ser_item.dataset_image.image.levels.unwrap();
+        let level_0 = ser_item
+            .dataset_image
+            .expect("Image expected")
+            .image
+            .expect("levels expected")
+            .levels
+            .unwrap();
         assert_eq!(
             level_0.image_levels.get(&0).unwrap().format,
             "png".to_string()
         );
-        assert_eq!(level_0.base_key, "some-base-key.jpg".to_string());
+        assert_eq!(level_0.base_key, Some("some-base-key.jpg".to_string()));
     }
 
     #[test]

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -77,19 +77,19 @@ pub struct Stage {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
 pub struct TemplateAssignee {
-    pub assignee_id: u32,
-    pub sampling_rate: f64,
+    pub assignee_id: Option<u32>,
+    pub sampling_rate: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
 pub struct WorkflowStageTemplate {
     pub id: Option<u32>,
-    pub metadata: TemplateMetadata,
+    pub metadata: Option<TemplateMetadata>,
     pub name: Option<String>,
-    pub workflow_stage_template_assignees: Vec<TemplateAssignee>,
+    pub workflow_stage_template_assignees: Vec<Option<TemplateAssignee>>,
     pub stage_number: Option<usize>,
     #[serde(rename = "type")]
-    pub stage_type: StageType,
+    pub stage_type: Option<StageType>,
     pub workflow_template_id: Option<u32>,
 }
 
@@ -106,7 +106,7 @@ pub struct Workflow {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy)]
 pub struct WorkflowTemplate {
-    pub dataset_id: u32,
+    pub dataset_id: Option<u32>,
     pub id: Option<u32>,
     pub name: Option<String>,
     pub workflow_stage_templates: Vec<WorkflowStageTemplate>,
@@ -201,7 +201,7 @@ pub struct StageConfig {
     pub from_non_default_v1_template: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_annotations: Option<bool>,
-    pub initial: bool,
+    pub initial: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub iou_thresholds: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -261,7 +261,7 @@ pub struct WorkflowV2 {
     pub name: Option<String>,
     pub progress: Option<WorkflowProgress>,
     pub stages: Vec<Option<WorkflowStageV2>>,
-    pub team_id: u32,
+    pub team_id: Option<u32>,
     pub thumbnails: Vec<Option<String>>,
     pub updated_at: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## [🛠️ Refactor] Implement Optional Properties in `datasets.rs` of `darwin-v7`

### For the Reviewer
📚 **Please review this PR according to the [conventional comments](https://conventionalcomments.org/) guide.**

### Related Tasks

### Depends on

### What

🔨 **API Response Refactor in `datasets.rs`:**
- Updated the `datasets.rs` module in `darwin-v7` to wrap all API response properties in `Option<>`.
- Changes include:
  - Making basic data types like `String` optional (`Option<String>`).
  - Applying `Option<>` to complex types such as structs (e.g., `Option<Annotator>`).
  - Using a double-option approach for collections (e.g., `Vec<Option<String>>`) to address both the collection's presence and the possibility of null items within it.

### Why

🎯 **Rationale & Context:**
- The V7 API has exhibited inconsistencies in response types, deviating from the documented specifications.
- Wrapping response properties in `Option<>` in the `datasets.rs` module allows for more resilient handling of these inconsistencies.
- This change aims to prevent API call failures due to missing or incorrect properties, thereby improving the stability and reliability of interactions with the V7 API within `darwin-v7`.

### Concerns

### Notes

### Integration with `fra-datalake` and Branch Strategy

The update in `datasets.rs` is crucial for maintaining the integrity of data interactions with `fra-datalake`, especially under varying API response conditions. Our strategy:

1. **Dedicated Feature Branch:** The refactor of the `datasets.rs` module is carried out in a specific feature branch to isolate and focus on these changes.
2. **Merge into `chore/FRA-609-option-responses`:** After review and testing, this branch will be merged into `chore/FRA-609-option-responses` via a PR.
3. **Testing with `fra-datalake`:** The `chore/FRA-609-option-responses` branch will be employed for testing in conjunction with `fra-datalake`.
4. **Final Integration:** Upon successful testing, these improvements will be integrated into the main branch, ensuring enhanced resilience in dataset operations.

**Tracking via JIRA Ticket:**
The integration and testing process with `fra-datalake` is tracked under [FRADATA-620](https://franklin-ai.atlassian.net/browse/FRADATA-620).

[FRADATA-620]: https://franklin-ai.atlassian.net/browse/FRADATA-620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
