### PR TITLE
chore: remove v1 structs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,5 +1,5 @@
 use crate::{config::Config, team::Team};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use log::debug;
 use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
@@ -103,24 +103,6 @@ pub struct V7Client {
     api_key: String,
     team: String,
     client: RawClient,
-}
-
-#[derive(Debug, Default, Clone)]
-pub enum ApiVersion {
-    #[default]
-    V1,
-    V2,
-}
-
-impl ApiVersion {
-    pub fn try_from(version: &str) -> Result<Self> {
-        let api_version = match version {
-            "v1" => ApiVersion::V1,
-            "v2" => ApiVersion::V2,
-            _ => bail!(format!("Error: {} is not a valid API version", version)),
-        };
-        Ok(api_version)
-    }
 }
 
 #[async_trait]

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -7,8 +7,7 @@ use crate::expect_http_ok;
 use crate::filter::Filter;
 use crate::imports::AnnotationImport;
 use crate::item::{
-    AddDataPayload, DataPayloadLevel, DatasetItemStatus, DatasetItemTypes,
-    ExistingSimpleItem, Item,
+    AddDataPayload, DataPayloadLevel, DatasetItemStatus, DatasetItemTypes, ExistingSimpleItem, Item,
 };
 use crate::team::TypeCount;
 use crate::workflow::{WorkflowBuilder, WorkflowMethods, WorkflowV2};
@@ -372,7 +371,6 @@ pub trait DatasetArchiveMethods<C>
 where
     C: V7Methods,
 {
-    // async fn archive_all_files(&self, client: &C) -> Result<()>;
     async fn archive_items(&self, client: &C, filter: &Filter) -> Result<ArchiveResponseItems>;
     async fn archive_dataset(&self, client: &C) -> Result<Dataset>;
 }
@@ -457,11 +455,6 @@ where
 {
     async fn reset_to_new(&self, client: &C, filter: &Filter) -> Result<()>;
     async fn set_workflow_v2(&self, client: &C, workflow: &WorkflowBuilder) -> Result<WorkflowV2>;
-    // async fn set_default_workflow(
-    //     &self,
-    //     client: &C,
-    //     workflow: &WorkflowTemplate,
-    // ) -> Result<Dataset>;
     async fn get_workflow_v2(&self, client: &C) -> Result<Option<WorkflowV2>>;
     async fn set_stage_v2(
         &self,
@@ -485,19 +478,6 @@ impl<C> DatasetArchiveMethods<C> for Dataset
 where
     C: V7Methods + std::marker::Sync,
 {
-    // async fn archive_all_files(&self, client: &C) -> Result<()> {
-    //     let item_ids: Vec<u32> = Dataset::list_dataset_items(client)
-    //         .await?
-    //         .iter()
-    //         .filter(|x| !x.archived)
-    //         .map(|x| x.id.clone())
-    //         .collect();
-    //     let mut filter = Filter::default();
-    //     filter.dataset_item_ids = Some(item_ids);
-
-    //     self.archive_items(client, &filter).await
-    // }
-
     /// The docs say a reason is required, but the call actually fails if it is provided
     /// https://docs.v7labs.com/v1.0/reference/archive
     async fn archive_items(&self, client: &C, filter: &Filter) -> Result<ArchiveResponseItems> {
@@ -804,25 +784,6 @@ where
         }
         Ok(response.json().await?)
     }
-
-    // async fn set_default_workflow(
-    //     &self,
-    //     client: &C,
-    //     workflow: &WorkflowTemplate,
-    // ) -> Result<Dataset> {
-    //     let workflow_id = workflow.id.as_ref().context("Workflow id not provided")?;
-    //
-    //     let endpoint = format!(
-    //         "datasets/{}/default_workflow_template/{}",
-    //         self.id.context("Dataset is missing Id")?,
-    //         workflow_id
-    //     );
-    //     let payload: Option<&WorkflowTemplate> = None;
-    //     let response = client.put(&endpoint, payload).await?;
-    //
-    //     expect_http_ok!(response, Dataset)
-    // }
-
     async fn get_workflow_v2(&self, client: &C) -> Result<Option<WorkflowV2>> {
         let workflows = WorkflowV2::get_workflows(client).await?;
         let dataset_name = self.name.as_ref().context("Missing dataset name")?;
@@ -906,7 +867,6 @@ impl Display for Dataset {
 
 #[cfg(test)]
 mod test_client_calls {
-
     use super::*;
     use crate::client::V7Client;
 
@@ -914,9 +874,10 @@ mod test_client_calls {
 
     // Utilizing Faker with an AlwaysTrueRng to guarantee that all Option types are populated with Some values
     // This ensures consistent data generation where no field is left as None
+    use crate::item::DatasetItemV2;
     use fake::utils::AlwaysTrueRng;
     use serde_json::json;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[tokio::test]
@@ -999,70 +960,56 @@ mod test_client_calls {
             .expect_err("error decoding response body: expected value at line 1 column 1");
     }
 
-    // #[tokio::test]
-    // async fn test_list_dataset_items() {
-    //     let mock_server = MockServer::start().await;
-    //     let mut rng = AlwaysTrueRng::default();
-    //     let mock_data: Dataset = Faker.fake_with_rng(&mut rng);
-    //
-    //     let dset_id = mock_data.id.expect("Id must be set");
-    //
-    //     let mock_dataset_item = DatasetItem {
-    //         dataset_id: Some(987),
-    //         dataset_image: Some(DatasetImage {
-    //             dataset_id: Some(987),
-    //             image: Some(Image {
-    //                 levels: Some(Levels {
-    //                     image_levels: Default::default(),
-    //                     base_key: Some("mock".to_string()),
-    //                 }),
-    //                 ..Default::default()
-    //             }),
-    //             ..Default::default()
-    //         }),
-    //
-    //         id: Some(123),
-    //
-    //         ..Default::default()
-    //     };
-    //
-    //     // Just generate two random values for comparison
-    //     let mock_result_vec: Vec<DatasetItem> = vec![mock_dataset_item; 2];
-    //
-    //     let client: V7Client = V7Client::new(
-    //         format!("{}/", mock_server.uri()),
-    //         "api-key".to_string(),
-    //         "some-team".to_string(),
-    //     )
-    //     .expect("Failed to get V7Client");
-    //
-    //     Mock::given(method("GET"))
-    //         .and(path(format!("/datasets/{dset_id}/items")))
-    //         .respond_with(ResponseTemplate::new(200).set_body_json(mock_result_vec.clone()))
-    //         .mount(&mock_server)
-    //         .await;
-    //
-    //     #[allow(deprecated)]
-    //     let result: Vec<Option<DatasetItem>> = mock_data
-    //         .list_dataset_items(&client)
-    //         .await
-    //         .expect("Failed to list dataset items");
-    //
-    //     // Only compare a few values, this is mostly testing the endpoint
-    //     // invocation and not serde.
-    //     assert_eq!(result.len(), mock_result_vec.len());
-    //     assert_eq!(
-    //         result[0].as_ref().expect("Expected dataset").status,
-    //         mock_result_vec[0].status
-    //     );
-    //     assert_eq!(
-    //         result[result.len() - 1]
-    //             .as_ref()
-    //             .expect("Expected dataset")
-    //             .id,
-    //         mock_result_vec[mock_result_vec.len() - 1].id
-    //     );
-    // }
+    #[tokio::test]
+    async fn test_list_dataset_items() {
+        let mock_server = MockServer::start().await;
+        let mut rng = AlwaysTrueRng::default();
+        let mut mock_data: Dataset = Faker.fake_with_rng(&mut rng);
+        mock_data.team_slug = Some("some-team".to_string());
+
+        let dset_id = mock_data.id.expect("Id must be set");
+
+        // Just generate two random values for comparison
+        // let mock_result_vec: Vec<DatasetItemV2> = vec![mock_dataset_item; 2];
+        let mock_result: Item = Item {
+            items: vec![Some(DatasetItemV2 {
+                id: Some("123".to_string()),
+                ..Default::default()
+            })],
+            ..Default::default()
+        };
+
+        let mock_items: Vec<_> = mock_result.items.iter().flatten().collect();
+
+        let client: V7Client = V7Client::new(
+            format!("{}/", mock_server.uri()),
+            "api-key".to_string(),
+            "some-team".to_string(),
+        )
+        .expect("Failed to get V7Client");
+
+        Mock::given(method("GET"))
+            .and(path("/v2/teams/some-team/items"))
+            .and(query_param("dataset_ids".to_string(), dset_id.to_string()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(mock_result.clone()))
+            .mount(&mock_server)
+            .await;
+
+        let result = mock_data
+            .list_dataset_items_v2(&client)
+            .await
+            .expect("Failed to list dataset items");
+        let expected_items: Vec<_> = result.items.iter().flatten().collect();
+
+        // Only compare a few values, this is mostly testing the endpoint
+        // invocation and not serde.
+        assert_eq!(expected_items.len(), mock_items.len());
+        assert_eq!(expected_items[0].status, mock_items[0].status);
+        assert_eq!(
+            expected_items[expected_items.len() - 1].id,
+            mock_items[mock_items.len() - 1].id
+        );
+    }
 
     #[tokio::test]
     async fn test_archive_dataset_items() {
@@ -1109,31 +1056,30 @@ mod test_client_calls {
 
     #[tokio::test]
     async fn test_list_dataset_items_status_error() {
-        // let mock_server = MockServer::start().await;
-        //
-        // let mut rng = AlwaysTrueRng::default();
-        // let mock_data: Dataset = Faker.fake_with_rng(&mut rng);
-        // let dset_id = mock_data.id.expect("Id must be set");
-        //
-        // Mock::given(method("GET"))
-        //     .and(path(format!("/datasets/{dset_id}/items")))
-        //     .respond_with(ResponseTemplate::new(412))
-        //     .mount(&mock_server)
-        //     .await;
-        //
-        // let client: V7Client = V7Client::new(
-        //     format!("{}/", mock_server.uri()),
-        //     "api-key".to_string(),
-        //     "some-team".to_string(),
-        // )
-        // .expect("Failed to get V7 Client");
-        //
-        // #[allow(deprecated)]
-        // mock_data
-        //     .list_dataset_items(&client)
-        //     .await
-        //     .expect_err("Invalid status code 412");
-        // FIXME
+        let mock_server = MockServer::start().await;
+
+        let mut rng = AlwaysTrueRng::default();
+        let mock_data: Dataset = Faker.fake_with_rng(&mut rng);
+        let dset_id = mock_data.id.expect("Id must be set");
+
+        Mock::given(method("GET"))
+            .and(path("/v2/teams/some-team/items"))
+            .and(query_param("dataset_ids".to_string(), dset_id.to_string()))
+            .respond_with(ResponseTemplate::new(412))
+            .mount(&mock_server)
+            .await;
+
+        let client: V7Client = V7Client::new(
+            format!("{}/", mock_server.uri()),
+            "api-key".to_string(),
+            "some-team".to_string(),
+        )
+        .expect("Failed to get V7 Client");
+
+        mock_data
+            .list_dataset_items_v2(&client)
+            .await
+            .expect_err("Invalid status code 412");
     }
 
     #[tokio::test]

--- a/src/export.rs
+++ b/src/export.rs
@@ -13,31 +13,6 @@ pub struct Annotator {
     // or reviewer
     pub full_name: String,
 }
-
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
-
-pub struct ImageExport {
-    // Internal filename on Darwin
-    pub filename: String,
-    // Height of the image
-    pub height: u32,
-    // Original filename
-    pub original_filename: String,
-    // Path of file within Darwin
-    pub path: String,
-    // Sequence number is a monotonic increasing number
-    // for each file uploaded int a Darwin Dataset.
-    //seq: u64,
-    // The URL of the image thumbnail
-    pub thumbnail_url: String,
-    //THe URL within V7 of the image
-    pub url: String,
-    // Width of the image
-    pub width: u32,
-    // The URL of the image on Darwin
-    pub workview_url: String,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct ImageAnnotation {
     // ID of the annotation
@@ -60,13 +35,6 @@ pub struct ImageAnnotation {
     // Annotation Type
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<Text>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
-pub struct JsonExport {
-    pub annotations: Vec<ImageAnnotation>,
-    pub dataset: String,
-    pub image: ImageExport,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]

--- a/src/item.rs
+++ b/src/item.rs
@@ -316,13 +316,12 @@ pub struct ExistingSimpleItem {
 }
 
 impl Display for DatasetItemV2 {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // write!(
-        //     f,
-        //     "{{id-{:?}}}:{:?}/{:?}[{:?}]",
-        //     self.id, self.filename, self.status, self.item_type
-        // )
-        todo!()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{{id-{:?}}}:{:?}/{:?}[{:?}]",
+            self.id, self.name, self.status, self.slot_types
+        )
     }
 }
 
@@ -360,7 +359,7 @@ pub struct DatasetItemLayout {
     pub version: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Dummy)]
 pub struct DatasetItemV2 {
     pub archived: Option<bool>,
     pub cursor: Option<String>,
@@ -381,7 +380,7 @@ pub struct DatasetItemV2 {
     pub workflow_status: Option<StageType>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Dummy)]
 pub struct ItemPage {
     pub count: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -389,7 +388,7 @@ pub struct ItemPage {
     pub previous: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Dummy)]
 pub struct Item {
     pub items: Vec<Option<DatasetItemV2>>,
     pub page: ItemPage,
@@ -455,127 +454,6 @@ mod test_serde {
         serde_json::from_str::<Levels>(r#"{"key": "value"}"#)
             .expect_err("a map with keys '0'..'N' and 'base_key'");
     }
-
-    // #[test]
-    // fn test_shortened_item() {
-    //     let contents = r#"
-    // {
-    //     "archived": false,
-    //     "archived_reason": null,
-    //     "current_workflow": {
-    //         "current_stage_number": 4,
-    //         "current_workflow_stage_template_id": 166369,
-    //         "dataset_item_id": 650713507,
-    //         "id": 43051890,
-    //         "stages": {
-    //             "1": [
-    //                 {
-    //                     "assignee_id": 12974,
-    //                     "completed": false,
-    //                     "completes_at": null,
-    //                     "dataset_item_id": 650713507,
-    //                     "id": 115470255,
-    //                     "metadata": {},
-    //                     "number": 1,
-    //                     "skipped": false,
-    //                     "skipped_reason": null,
-    //                     "template_metadata": {
-    //                         "assignable_to": "any_user",
-    //                         "base_sampling_rate": 1.0,
-    //                         "parallel": 1,
-    //                         "user_sampling_rate": 1.0
-    //                     },
-    //                     "type": "annotate",
-    //                     "workflow_id": 43051890,
-    //                     "workflow_stage_template_id": 166366
-    //                 }
-    //             ]
-    //         },
-    //         "status": "complete",
-    //         "workflow_template_id": 53975
-    //     },
-    //     "current_workflow_id": 43051890,
-    //     "dataset_id": 587733,
-    //     "dataset_image": {
-    //         "dataset_id": 587733,
-    //         "dataset_video_id": null,
-    //         "id": 646799980,
-    //         "image": {
-    //             "external": true,
-    //             "format": "tiled",
-    //             "height": 44038,
-    //             "id": 620657191,
-    //             "key": "9841162f-3f4c-4434-be99-2c2d26c6856b",
-    //             "levels": {
-    //                 "0": {
-    //                     "format": "png",
-    //                     "pixel_ratio": 1,
-    //                     "tile_height": 2048,
-    //                     "tile_width": 2048,
-    //                     "x_tiles": 82,
-    //                     "y_tiles": 22
-    //                 },
-    //                 "base_key": "some-base-key.jpg"
-    //             },
-    //             "original_filename": "9841162f-3f4c-4434-be99-2c2d26c6856b",
-    //             "thumbnail_url": "https://great-thumbnail.thing.foo",
-    //             "uploaded": true,
-    //             "url": "https://url-to.thing.foo",
-    //             "width": 166918
-    //         },
-    //         "seq": 1,
-    //         "set": 1669945183
-    //     },
-    //     "dataset_image_id": 646799980,
-    //     "dataset_video": null,
-    //     "dataset_video_id": null,
-    //     "file_size": 0,
-    //     "filename": "9841162f-3f4c-4434-be99-2c2d26c6856b",
-    //     "height": 44038,
-    //     "id": 650713507,
-    //     "inserted_at": "2022-12-02T01:39:43",
-    //     "labels": [
-    //         189358,
-    //         189395,
-    //         189403
-    //     ],
-    //     "path": "/",
-    //     "priority": 0,
-    //     "seq": 1,
-    //     "set": 1669945183,
-    //     "status": "complete",
-    //     "type": "image",
-    //     "updated_at": "2022-12-14T00:28:33",
-    //     "width": 166918
-    // }
-    //     "#;
-    //
-    //     let ser_item: DatasetItem = serde_json::from_str(contents).unwrap();
-    //
-    //     assert_eq!(ser_item.status, Some(DatasetItemStatus::Complete));
-    //     assert_eq!(ser_item.dataset_image_id, Some(646799980));
-    //     assert_eq!(ser_item.labels.unwrap().len(), 3);
-    //     assert!(ser_item
-    //         .current_workflow
-    //         .unwrap()
-    //         .stages
-    //         .keys()
-    //         .copied()
-    //         .any(|x| x == 1));
-    //
-    //     let level_0 = ser_item
-    //         .dataset_image
-    //         .expect("Image expected")
-    //         .image
-    //         .expect("levels expected")
-    //         .levels
-    //         .unwrap();
-    //     assert_eq!(
-    //         level_0.image_levels.get(&0).unwrap().format,
-    //         "png".to_string()
-    //     );
-    //     assert_eq!(level_0.base_key, Some("some-base-key.jpg".to_string()));
-    // }
 
     #[test]
     fn test_dataset_item_v2() {

--- a/src/item.rs
+++ b/src/item.rs
@@ -1,4 +1,4 @@
-use crate::workflow::{StageType, Workflow};
+use crate::workflow::StageType;
 use anyhow::{bail, Result};
 use fake::{Dummy, Fake, Faker};
 use serde::ser::SerializeMap;
@@ -315,42 +315,14 @@ pub struct ExistingSimpleItem {
     pub slots: Vec<Slot>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy)]
-pub struct DatasetItem {
-    pub archived: Option<bool>,
-    pub archived_reason: Option<String>,
-    pub current_workflow: Option<Workflow>,
-    pub current_workflow_id: Option<u32>,
-    pub dataset_id: Option<u32>,
-    pub dataset_image: Option<DatasetImage>,
-    pub dataset_image_id: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub dataset_video: Option<DatasetVideo>,
-    pub dataset_video_id: Option<u32>,
-    pub file_size: Option<u32>,
-    pub filename: Option<String>,
-    pub height: Option<u32>,
-    pub width: Option<u32>,
-    pub id: Option<u32>,
-    pub inserted_at: Option<String>,
-    pub updated_at: Option<String>,
-    pub labels: Option<Vec<u32>>,
-    pub path: Option<String>,
-    pub priority: Option<u32>,
-    pub seq: Option<u32>,
-    pub set: Option<u32>,
-    pub status: Option<DatasetItemStatus>,
-    #[serde(rename = "type")]
-    pub item_type: Option<DatasetItemTypes>, // This can probably be an enum
-}
-
-impl Display for DatasetItem {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{{id-{:?}}}:{:?}/{:?}[{:?}]",
-            self.id, self.filename, self.status, self.item_type
-        )
+impl Display for DatasetItemV2 {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // write!(
+        //     f,
+        //     "{{id-{:?}}}:{:?}/{:?}[{:?}]",
+        //     self.id, self.filename, self.status, self.item_type
+        // )
+        todo!()
     }
 }
 
@@ -484,126 +456,126 @@ mod test_serde {
             .expect_err("a map with keys '0'..'N' and 'base_key'");
     }
 
-    #[test]
-    fn test_shortened_item() {
-        let contents = r#"
-    {
-        "archived": false,
-        "archived_reason": null,
-        "current_workflow": {
-            "current_stage_number": 4,
-            "current_workflow_stage_template_id": 166369,
-            "dataset_item_id": 650713507,
-            "id": 43051890,
-            "stages": {
-                "1": [
-                    {
-                        "assignee_id": 12974,
-                        "completed": false,
-                        "completes_at": null,
-                        "dataset_item_id": 650713507,
-                        "id": 115470255,
-                        "metadata": {},
-                        "number": 1,
-                        "skipped": false,
-                        "skipped_reason": null,
-                        "template_metadata": {
-                            "assignable_to": "any_user",
-                            "base_sampling_rate": 1.0,
-                            "parallel": 1,
-                            "user_sampling_rate": 1.0
-                        },
-                        "type": "annotate",
-                        "workflow_id": 43051890,
-                        "workflow_stage_template_id": 166366
-                    }
-                ]
-            },
-            "status": "complete",
-            "workflow_template_id": 53975
-        },
-        "current_workflow_id": 43051890,
-        "dataset_id": 587733,
-        "dataset_image": {
-            "dataset_id": 587733,
-            "dataset_video_id": null,
-            "id": 646799980,
-            "image": {
-                "external": true,
-                "format": "tiled",
-                "height": 44038,
-                "id": 620657191,
-                "key": "9841162f-3f4c-4434-be99-2c2d26c6856b",
-                "levels": {
-                    "0": {
-                        "format": "png",
-                        "pixel_ratio": 1,
-                        "tile_height": 2048,
-                        "tile_width": 2048,
-                        "x_tiles": 82,
-                        "y_tiles": 22
-                    },
-                    "base_key": "some-base-key.jpg"
-                },
-                "original_filename": "9841162f-3f4c-4434-be99-2c2d26c6856b",
-                "thumbnail_url": "https://great-thumbnail.thing.foo",
-                "uploaded": true,
-                "url": "https://url-to.thing.foo",
-                "width": 166918
-            },
-            "seq": 1,
-            "set": 1669945183
-        },
-        "dataset_image_id": 646799980,
-        "dataset_video": null,
-        "dataset_video_id": null,
-        "file_size": 0,
-        "filename": "9841162f-3f4c-4434-be99-2c2d26c6856b",
-        "height": 44038,
-        "id": 650713507,
-        "inserted_at": "2022-12-02T01:39:43",
-        "labels": [
-            189358,
-            189395,
-            189403
-        ],
-        "path": "/",
-        "priority": 0,
-        "seq": 1,
-        "set": 1669945183,
-        "status": "complete",
-        "type": "image",
-        "updated_at": "2022-12-14T00:28:33",
-        "width": 166918
-    }
-        "#;
-
-        let ser_item: DatasetItem = serde_json::from_str(contents).unwrap();
-
-        assert_eq!(ser_item.status, Some(DatasetItemStatus::Complete));
-        assert_eq!(ser_item.dataset_image_id, Some(646799980));
-        assert_eq!(ser_item.labels.unwrap().len(), 3);
-        assert!(ser_item
-            .current_workflow
-            .unwrap()
-            .stages
-            .keys()
-            .copied()
-            .any(|x| x == 1));
-
-        let level_0 = ser_item
-            .dataset_image
-            .expect("Image expected")
-            .image
-            .expect("levels expected")
-            .levels
-            .unwrap();
-        assert_eq!(
-            level_0.image_levels.get(&0).unwrap().format,
-            "png".to_string()
-        );
-        assert_eq!(level_0.base_key, Some("some-base-key.jpg".to_string()));
-    }
+    // #[test]
+    // fn test_shortened_item() {
+    //     let contents = r#"
+    // {
+    //     "archived": false,
+    //     "archived_reason": null,
+    //     "current_workflow": {
+    //         "current_stage_number": 4,
+    //         "current_workflow_stage_template_id": 166369,
+    //         "dataset_item_id": 650713507,
+    //         "id": 43051890,
+    //         "stages": {
+    //             "1": [
+    //                 {
+    //                     "assignee_id": 12974,
+    //                     "completed": false,
+    //                     "completes_at": null,
+    //                     "dataset_item_id": 650713507,
+    //                     "id": 115470255,
+    //                     "metadata": {},
+    //                     "number": 1,
+    //                     "skipped": false,
+    //                     "skipped_reason": null,
+    //                     "template_metadata": {
+    //                         "assignable_to": "any_user",
+    //                         "base_sampling_rate": 1.0,
+    //                         "parallel": 1,
+    //                         "user_sampling_rate": 1.0
+    //                     },
+    //                     "type": "annotate",
+    //                     "workflow_id": 43051890,
+    //                     "workflow_stage_template_id": 166366
+    //                 }
+    //             ]
+    //         },
+    //         "status": "complete",
+    //         "workflow_template_id": 53975
+    //     },
+    //     "current_workflow_id": 43051890,
+    //     "dataset_id": 587733,
+    //     "dataset_image": {
+    //         "dataset_id": 587733,
+    //         "dataset_video_id": null,
+    //         "id": 646799980,
+    //         "image": {
+    //             "external": true,
+    //             "format": "tiled",
+    //             "height": 44038,
+    //             "id": 620657191,
+    //             "key": "9841162f-3f4c-4434-be99-2c2d26c6856b",
+    //             "levels": {
+    //                 "0": {
+    //                     "format": "png",
+    //                     "pixel_ratio": 1,
+    //                     "tile_height": 2048,
+    //                     "tile_width": 2048,
+    //                     "x_tiles": 82,
+    //                     "y_tiles": 22
+    //                 },
+    //                 "base_key": "some-base-key.jpg"
+    //             },
+    //             "original_filename": "9841162f-3f4c-4434-be99-2c2d26c6856b",
+    //             "thumbnail_url": "https://great-thumbnail.thing.foo",
+    //             "uploaded": true,
+    //             "url": "https://url-to.thing.foo",
+    //             "width": 166918
+    //         },
+    //         "seq": 1,
+    //         "set": 1669945183
+    //     },
+    //     "dataset_image_id": 646799980,
+    //     "dataset_video": null,
+    //     "dataset_video_id": null,
+    //     "file_size": 0,
+    //     "filename": "9841162f-3f4c-4434-be99-2c2d26c6856b",
+    //     "height": 44038,
+    //     "id": 650713507,
+    //     "inserted_at": "2022-12-02T01:39:43",
+    //     "labels": [
+    //         189358,
+    //         189395,
+    //         189403
+    //     ],
+    //     "path": "/",
+    //     "priority": 0,
+    //     "seq": 1,
+    //     "set": 1669945183,
+    //     "status": "complete",
+    //     "type": "image",
+    //     "updated_at": "2022-12-14T00:28:33",
+    //     "width": 166918
+    // }
+    //     "#;
+    //
+    //     let ser_item: DatasetItem = serde_json::from_str(contents).unwrap();
+    //
+    //     assert_eq!(ser_item.status, Some(DatasetItemStatus::Complete));
+    //     assert_eq!(ser_item.dataset_image_id, Some(646799980));
+    //     assert_eq!(ser_item.labels.unwrap().len(), 3);
+    //     assert!(ser_item
+    //         .current_workflow
+    //         .unwrap()
+    //         .stages
+    //         .keys()
+    //         .copied()
+    //         .any(|x| x == 1));
+    //
+    //     let level_0 = ser_item
+    //         .dataset_image
+    //         .expect("Image expected")
+    //         .image
+    //         .expect("levels expected")
+    //         .levels
+    //         .unwrap();
+    //     assert_eq!(
+    //         level_0.image_levels.get(&0).unwrap().format,
+    //         "png".to_string()
+    //     );
+    //     assert_eq!(level_0.base_key, Some("some-base-key.jpg".to_string()));
+    // }
 
     #[test]
     fn test_dataset_item_v2() {

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -1,4 +1,3 @@
-use crate::classes::BoundingBox;
 use crate::client::V7Methods;
 use crate::expect_http_ok;
 use anyhow::{bail, Context, Result};
@@ -40,15 +39,6 @@ impl Display for StageType {
     }
 }
 
-// #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
-// pub struct TemplateMetadata {
-//     pub assignable_to: Option<String>,
-//     pub base_sampling_rate: Option<f64>,
-//     pub parallel: Option<u32>,
-//     pub user_sampling_rate: Option<f64>,
-//     pub readonly: Option<bool>,
-// }
-
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
 pub struct MetaData {
     pub ready_for_completion: Option<bool>,
@@ -57,78 +47,11 @@ pub struct MetaData {
     pub review_status_modified_at: Option<String>,
 }
 
-// #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
-// pub struct Stage {
-//     pub assignee_id: Option<u32>,
-//     pub completed: Option<bool>,
-//     pub completes_at: Option<String>,
-//     pub dataset_item_id: Option<u32>,
-//     pub id: Option<u32>,
-//     pub metadata: Option<MetaData>,
-//     pub number: Option<u32>,
-//     pub skipped: Option<bool>,
-//     pub skipped_reason: Option<String>,
-//     pub template_metadata: Option<TemplateMetadata>,
-//     #[serde(rename = "type")]
-//     pub stage_type: Option<StageType>,
-//     pub workflow_id: Option<u32>,
-//     pub workflow_stage_template_id: Option<u32>,
-// }
-
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
 pub struct TemplateAssignee {
     pub assignee_id: Option<u32>,
     pub sampling_rate: Option<f64>,
 }
-
-// #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
-// pub struct WorkflowStageTemplate {
-//     pub id: Option<u32>,
-//     pub metadata: Option<TemplateMetadata>,
-//     pub name: Option<String>,
-//     pub workflow_stage_template_assignees: Vec<Option<TemplateAssignee>>,
-//     pub stage_number: Option<usize>,
-//     #[serde(rename = "type")]
-//     pub stage_type: Option<StageType>,
-//     pub workflow_template_id: Option<u32>,
-// }
-// #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy)]
-// pub struct WorkflowTemplate {
-//     pub dataset_id: Option<u32>,
-//     pub id: Option<u32>,
-//     pub name: Option<String>,
-//     pub workflow_stage_templates: Vec<Option<WorkflowStageTemplate>>,
-// }
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
-pub struct WorkflowBody {
-    pub body: String,
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
-pub struct LocatedWorkflowComments {
-    pub bounding_box: BoundingBox,
-    pub workflow_comments: Vec<WorkflowBody>,
-}
-
-// #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
-// pub struct WorkflowCommentThread {
-//     pub author_id: Option<u32>,
-//     pub bounding_box: Option<BoundingBox>,
-//     pub comment_count: Option<u32>,
-//     pub frame_index: Option<u32>,
-//     pub id: Option<u32>,
-//     pub inserted_at: Option<String>,
-//     pub resolved: Option<bool>,
-//     pub updated_at: Option<String>,
-//     pub workflow_id: Option<u32>,
-// }
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
-struct UserId {
-    pub user_id: u32,
-}
-
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
 pub struct FilterAssignItemPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -338,74 +261,6 @@ where
     }
 }
 
-// impl Workflow {
-    // pub async fn assign<C>(&self, client: &C, user_id: &u32) -> Result<Workflow>
-    // where
-    //     C: V7Methods,
-    // {
-    //     let user = UserId { user_id: *user_id };
-    //
-    //     let response = client
-    //         .post(
-    //             &format!("workflow_stages/{}/assign", self.id.context("Id required")?),
-    //             &user,
-    //         )
-    //         .await?;
-    //
-    //     expect_http_ok!(response, Workflow)
-    // }
-
-    // /// Warning undocumented
-    // pub async fn add_comment<C>(
-    //     &self,
-    //     client: &C,
-    //     comments: &LocatedWorkflowComments,
-    // ) -> Result<WorkflowCommentThread>
-    // where
-    //     C: V7Methods,
-    // {
-    //     let response = client
-    //         .post(
-    //             &format!(
-    //                 "workflows/{}/workflow_comment_threads",
-    //                 self.id.context("Id required")?
-    //             ),
-    //             comments,
-    //         )
-    //         .await?;
-    //
-    //     expect_http_ok!(response, WorkflowCommentThread)
-    // }
-// }
-
-// impl WorkflowTemplate {
-//     pub async fn get<C>(client: &C, id: &u32) -> Result<WorkflowTemplate>
-//     where
-//         C: V7Methods,
-//     {
-//         let response = client.get(&format!("workflow_templates/{}", id)).await?;
-//
-//         expect_http_ok!(response, WorkflowTemplate)
-//     }
-// }
-
-// impl WorkflowStageTemplate {
-//     pub async fn assign<C>(&self, client: &C) -> Result<WorkflowStageTemplate>
-//     where
-//         C: V7Methods,
-//     {
-//         let id = self
-//             .id
-//             .as_ref()
-//             .context("WorkflowStageTemplate id not specified")?;
-//         let response = client
-//             .put(&format!("workflow_stage_templates/{}", id), Some(&self))
-//             .await?;
-//
-//         expect_http_ok!(response, WorkflowStageTemplate)
-//     }
-// }
-
 #[cfg(test)]
 mod test_serde {
     use super::*;
@@ -453,23 +308,6 @@ mod test_serde {
             Some("2022-12-14T00:28:28.759303".to_string())
         );
     }
-
-    // #[test]
-    // fn test_template_metadata() {
-    //     let contents = "{
-    //         \"assignable_to\": \"any_user\",
-    //         \"base_sampling_rate\": 1.0,
-    //         \"parallel\": 1,
-    //         \"user_sampling_rate\": 1.0
-    //     }";
-    //
-    //     let template_meta: TemplateMetadata = serde_json::from_str(contents).unwrap();
-    //
-    //     assert_eq!(template_meta.assignable_to, Some("any_user".to_string()));
-    //     assert_eq!(template_meta.base_sampling_rate, Some(1.0));
-    //     assert_eq!(template_meta.parallel, Some(1));
-    //     assert_eq!(template_meta.user_sampling_rate, Some(1.0));
-    // }
 
     #[test]
     fn test_display_stage_type() {
@@ -525,42 +363,71 @@ mod test_serde {
 
     #[test]
     fn test_ser_stage() {
-        // let contents = r#"
-        // {
-        //     "assignee_id": 12974,
-        //     "completed": false,
-        //     "completes_at": null,
-        //     "dataset_item_id": 650713507,
-        //     "id": 115470255,
-        //     "metadata": {},
-        //     "number": 1,
-        //     "skipped": false,
-        //     "skipped_reason": null,
-        //     "template_metadata": {
-        //         "assignable_to": "any_user",
-        //         "base_sampling_rate": 1.0,
-        //         "parallel": 1,
-        //         "user_sampling_rate": 1.0
-        //     },
-        //     "type": "annotate",
-        //     "workflow_id": 43051890,
-        //     "workflow_stage_template_id": 166366
-        // }
-        // "#;
-        //
-        // let stage: Stage = serde_json::from_str(contents).unwrap();
-        //
-        // assert_eq!(stage.assignee_id, Some(12974));
-        // assert_eq!(stage.completed, Some(false));
-        // assert_eq!(stage.completes_at, None);
-        // assert_eq!(stage.id, Some(115470255));
-        // assert_eq!(stage.metadata.unwrap().ready_for_completion, None);
-        // assert_eq!(
-        //     stage.template_metadata.unwrap().assignable_to,
-        //     Some("any_user".to_string())
-        // );
-        // assert_eq!(stage.stage_type, Some(StageType::Annotate));
+        let contents = r#"
+        {
+            "assignable_users": [],
+            "config": {
+              "allowed_class_ids": null,
+              "annotation_group_id": null,
+              "assignable_to": "anyone",
+              "authorization_header": null,
+              "auto_instantiate": false,
+              "champion_stage_id": null,
+              "class_mapping": [],
+              "dataset_id": null,
+              "from_non_default_v1_template": null,
+              "include_annotations": false,
+              "initial": false,
+              "iou_thresholds": null,
+              "model_id": null,
+              "model_type": "gust",
+              "parallel_stage_ids": null,
+              "readonly": false,
+              "retry_if_fails": false,
+              "rules": [],
+              "skippable": true,
+              "test_stage_id": null,
+              "threshold": null,
+              "url": null,
+              "x": 3746,
+              "y": 2896
+            },
+            "edges": [
+              {
+                "id": "fe2370d3-4091-4c35-83fe-871c9dc45f45",
+                "name": "reject",
+                "source_stage_id": "9bba4506-694d-4dd3-afd8-ab354c5a21ba",
+                "target_stage_id": "c95b5763-6da2-417a-bc06-106a45240ac0"
+              },
+              {
+                "id": "5b233988-46f7-4009-955d-4dbd89239d1e",
+                "name": "approve",
+                "source_stage_id": "9bba4506-694d-4dd3-afd8-ab354c5a21ba",
+                "target_stage_id": "3175bb69-b14e-4255-8bb3-3f19411dab4a"
+              }
+            ],
+            "id": "9bba4506-694d-4dd3-afd8-ab354c5a21ba",
+            "name": "Review",
+            "type": "review"
+        }
+        "#;
 
-        //FIXME
+        let stage: WorkflowStageV2 = serde_json::from_str(contents).unwrap();
+
+        assert_eq!(stage.stage_type, Some(StageType::Review));
+        assert_eq!(
+            stage.id,
+            Some("9bba4506-694d-4dd3-afd8-ab354c5a21ba".to_string())
+        );
+        assert_eq!(
+            stage.edges[0]
+                .clone()
+                .expect("Missing edge")
+                .source_stage_id,
+            stage.edges[1]
+                .clone()
+                .expect("Missing edge")
+                .source_stage_id
+        )
     }
 }

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -40,14 +40,14 @@ impl Display for StageType {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
-pub struct TemplateMetadata {
-    pub assignable_to: Option<String>,
-    pub base_sampling_rate: Option<f64>,
-    pub parallel: Option<u32>,
-    pub user_sampling_rate: Option<f64>,
-    pub readonly: Option<bool>,
-}
+// #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
+// pub struct TemplateMetadata {
+//     pub assignable_to: Option<String>,
+//     pub base_sampling_rate: Option<f64>,
+//     pub parallel: Option<u32>,
+//     pub user_sampling_rate: Option<f64>,
+//     pub readonly: Option<bool>,
+// }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
 pub struct MetaData {
@@ -57,23 +57,23 @@ pub struct MetaData {
     pub review_status_modified_at: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
-pub struct Stage {
-    pub assignee_id: Option<u32>,
-    pub completed: Option<bool>,
-    pub completes_at: Option<String>,
-    pub dataset_item_id: Option<u32>,
-    pub id: Option<u32>,
-    pub metadata: Option<MetaData>,
-    pub number: Option<u32>,
-    pub skipped: Option<bool>,
-    pub skipped_reason: Option<String>,
-    pub template_metadata: Option<TemplateMetadata>,
-    #[serde(rename = "type")]
-    pub stage_type: Option<StageType>,
-    pub workflow_id: Option<u32>,
-    pub workflow_stage_template_id: Option<u32>,
-}
+// #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
+// pub struct Stage {
+//     pub assignee_id: Option<u32>,
+//     pub completed: Option<bool>,
+//     pub completes_at: Option<String>,
+//     pub dataset_item_id: Option<u32>,
+//     pub id: Option<u32>,
+//     pub metadata: Option<MetaData>,
+//     pub number: Option<u32>,
+//     pub skipped: Option<bool>,
+//     pub skipped_reason: Option<String>,
+//     pub template_metadata: Option<TemplateMetadata>,
+//     #[serde(rename = "type")]
+//     pub stage_type: Option<StageType>,
+//     pub workflow_id: Option<u32>,
+//     pub workflow_stage_template_id: Option<u32>,
+// }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
 pub struct TemplateAssignee {
@@ -81,36 +81,24 @@ pub struct TemplateAssignee {
     pub sampling_rate: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
-pub struct WorkflowStageTemplate {
-    pub id: Option<u32>,
-    pub metadata: Option<TemplateMetadata>,
-    pub name: Option<String>,
-    pub workflow_stage_template_assignees: Vec<Option<TemplateAssignee>>,
-    pub stage_number: Option<usize>,
-    #[serde(rename = "type")]
-    pub stage_type: Option<StageType>,
-    pub workflow_template_id: Option<u32>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
-pub struct Workflow {
-    pub current_stage_number: Option<u32>,
-    pub current_workflow_stage_template_id: Option<u32>,
-    pub dataset_item_id: Option<u32>,
-    pub id: Option<u32>,
-    pub stages: HashMap<u32, Vec<Option<Stage>>>,
-    pub status: Option<String>, // This can probably be an enum
-    pub workflow_template_id: Option<u32>,
-}
-
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy)]
-pub struct WorkflowTemplate {
-    pub dataset_id: Option<u32>,
-    pub id: Option<u32>,
-    pub name: Option<String>,
-    pub workflow_stage_templates: Vec<Option<WorkflowStageTemplate>>,
-}
+// #[derive(Debug, Clone, Serialize, Deserialize, Dummy)]
+// pub struct WorkflowStageTemplate {
+//     pub id: Option<u32>,
+//     pub metadata: Option<TemplateMetadata>,
+//     pub name: Option<String>,
+//     pub workflow_stage_template_assignees: Vec<Option<TemplateAssignee>>,
+//     pub stage_number: Option<usize>,
+//     #[serde(rename = "type")]
+//     pub stage_type: Option<StageType>,
+//     pub workflow_template_id: Option<u32>,
+// }
+// #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy)]
+// pub struct WorkflowTemplate {
+//     pub dataset_id: Option<u32>,
+//     pub id: Option<u32>,
+//     pub name: Option<String>,
+//     pub workflow_stage_templates: Vec<Option<WorkflowStageTemplate>>,
+// }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
 pub struct WorkflowBody {
@@ -123,18 +111,18 @@ pub struct LocatedWorkflowComments {
     pub workflow_comments: Vec<WorkflowBody>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
-pub struct WorkflowCommentThread {
-    pub author_id: Option<u32>,
-    pub bounding_box: Option<BoundingBox>,
-    pub comment_count: Option<u32>,
-    pub frame_index: Option<u32>,
-    pub id: Option<u32>,
-    pub inserted_at: Option<String>,
-    pub resolved: Option<bool>,
-    pub updated_at: Option<String>,
-    pub workflow_id: Option<u32>,
-}
+// #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq)]
+// pub struct WorkflowCommentThread {
+//     pub author_id: Option<u32>,
+//     pub bounding_box: Option<BoundingBox>,
+//     pub comment_count: Option<u32>,
+//     pub frame_index: Option<u32>,
+//     pub id: Option<u32>,
+//     pub inserted_at: Option<String>,
+//     pub resolved: Option<bool>,
+//     pub updated_at: Option<String>,
+//     pub workflow_id: Option<u32>,
+// }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy, PartialEq, Eq)]
 struct UserId {
@@ -350,73 +338,73 @@ where
     }
 }
 
-impl Workflow {
-    pub async fn assign<C>(&self, client: &C, user_id: &u32) -> Result<Workflow>
-    where
-        C: V7Methods,
-    {
-        let user = UserId { user_id: *user_id };
+// impl Workflow {
+    // pub async fn assign<C>(&self, client: &C, user_id: &u32) -> Result<Workflow>
+    // where
+    //     C: V7Methods,
+    // {
+    //     let user = UserId { user_id: *user_id };
+    //
+    //     let response = client
+    //         .post(
+    //             &format!("workflow_stages/{}/assign", self.id.context("Id required")?),
+    //             &user,
+    //         )
+    //         .await?;
+    //
+    //     expect_http_ok!(response, Workflow)
+    // }
 
-        let response = client
-            .post(
-                &format!("workflow_stages/{}/assign", self.id.context("Id required")?),
-                &user,
-            )
-            .await?;
+    // /// Warning undocumented
+    // pub async fn add_comment<C>(
+    //     &self,
+    //     client: &C,
+    //     comments: &LocatedWorkflowComments,
+    // ) -> Result<WorkflowCommentThread>
+    // where
+    //     C: V7Methods,
+    // {
+    //     let response = client
+    //         .post(
+    //             &format!(
+    //                 "workflows/{}/workflow_comment_threads",
+    //                 self.id.context("Id required")?
+    //             ),
+    //             comments,
+    //         )
+    //         .await?;
+    //
+    //     expect_http_ok!(response, WorkflowCommentThread)
+    // }
+// }
 
-        expect_http_ok!(response, Workflow)
-    }
+// impl WorkflowTemplate {
+//     pub async fn get<C>(client: &C, id: &u32) -> Result<WorkflowTemplate>
+//     where
+//         C: V7Methods,
+//     {
+//         let response = client.get(&format!("workflow_templates/{}", id)).await?;
+//
+//         expect_http_ok!(response, WorkflowTemplate)
+//     }
+// }
 
-    /// Warning undocumented
-    pub async fn add_comment<C>(
-        &self,
-        client: &C,
-        comments: &LocatedWorkflowComments,
-    ) -> Result<WorkflowCommentThread>
-    where
-        C: V7Methods,
-    {
-        let response = client
-            .post(
-                &format!(
-                    "workflows/{}/workflow_comment_threads",
-                    self.id.context("Id required")?
-                ),
-                comments,
-            )
-            .await?;
-
-        expect_http_ok!(response, WorkflowCommentThread)
-    }
-}
-
-impl WorkflowTemplate {
-    pub async fn get<C>(client: &C, id: &u32) -> Result<WorkflowTemplate>
-    where
-        C: V7Methods,
-    {
-        let response = client.get(&format!("workflow_templates/{}", id)).await?;
-
-        expect_http_ok!(response, WorkflowTemplate)
-    }
-}
-
-impl WorkflowStageTemplate {
-    pub async fn assign<C>(&self, client: &C) -> Result<WorkflowStageTemplate>
-    where
-        C: V7Methods,
-    {
-        let id = self
-            .id
-            .as_ref()
-            .context("WorkflowStageTemplate id not specified")?;
-        let response = client
-            .put(&format!("workflow_stage_templates/{}", id), Some(&self))
-            .await?;
-
-        expect_http_ok!(response, WorkflowStageTemplate)
-    }
-}
+// impl WorkflowStageTemplate {
+//     pub async fn assign<C>(&self, client: &C) -> Result<WorkflowStageTemplate>
+//     where
+//         C: V7Methods,
+//     {
+//         let id = self
+//             .id
+//             .as_ref()
+//             .context("WorkflowStageTemplate id not specified")?;
+//         let response = client
+//             .put(&format!("workflow_stage_templates/{}", id), Some(&self))
+//             .await?;
+//
+//         expect_http_ok!(response, WorkflowStageTemplate)
+//     }
+// }
 
 #[cfg(test)]
 mod test_serde {
@@ -466,22 +454,22 @@ mod test_serde {
         );
     }
 
-    #[test]
-    fn test_template_metadata() {
-        let contents = "{
-            \"assignable_to\": \"any_user\",
-            \"base_sampling_rate\": 1.0,
-            \"parallel\": 1,
-            \"user_sampling_rate\": 1.0
-        }";
-
-        let template_meta: TemplateMetadata = serde_json::from_str(contents).unwrap();
-
-        assert_eq!(template_meta.assignable_to, Some("any_user".to_string()));
-        assert_eq!(template_meta.base_sampling_rate, Some(1.0));
-        assert_eq!(template_meta.parallel, Some(1));
-        assert_eq!(template_meta.user_sampling_rate, Some(1.0));
-    }
+    // #[test]
+    // fn test_template_metadata() {
+    //     let contents = "{
+    //         \"assignable_to\": \"any_user\",
+    //         \"base_sampling_rate\": 1.0,
+    //         \"parallel\": 1,
+    //         \"user_sampling_rate\": 1.0
+    //     }";
+    //
+    //     let template_meta: TemplateMetadata = serde_json::from_str(contents).unwrap();
+    //
+    //     assert_eq!(template_meta.assignable_to, Some("any_user".to_string()));
+    //     assert_eq!(template_meta.base_sampling_rate, Some(1.0));
+    //     assert_eq!(template_meta.parallel, Some(1));
+    //     assert_eq!(template_meta.user_sampling_rate, Some(1.0));
+    // }
 
     #[test]
     fn test_display_stage_type() {
@@ -537,40 +525,42 @@ mod test_serde {
 
     #[test]
     fn test_ser_stage() {
-        let contents = r#"
-        {
-            "assignee_id": 12974,
-            "completed": false,
-            "completes_at": null,
-            "dataset_item_id": 650713507,
-            "id": 115470255,
-            "metadata": {},
-            "number": 1,
-            "skipped": false,
-            "skipped_reason": null,
-            "template_metadata": {
-                "assignable_to": "any_user",
-                "base_sampling_rate": 1.0,
-                "parallel": 1,
-                "user_sampling_rate": 1.0
-            },
-            "type": "annotate",
-            "workflow_id": 43051890,
-            "workflow_stage_template_id": 166366
-        }
-        "#;
+        // let contents = r#"
+        // {
+        //     "assignee_id": 12974,
+        //     "completed": false,
+        //     "completes_at": null,
+        //     "dataset_item_id": 650713507,
+        //     "id": 115470255,
+        //     "metadata": {},
+        //     "number": 1,
+        //     "skipped": false,
+        //     "skipped_reason": null,
+        //     "template_metadata": {
+        //         "assignable_to": "any_user",
+        //         "base_sampling_rate": 1.0,
+        //         "parallel": 1,
+        //         "user_sampling_rate": 1.0
+        //     },
+        //     "type": "annotate",
+        //     "workflow_id": 43051890,
+        //     "workflow_stage_template_id": 166366
+        // }
+        // "#;
+        //
+        // let stage: Stage = serde_json::from_str(contents).unwrap();
+        //
+        // assert_eq!(stage.assignee_id, Some(12974));
+        // assert_eq!(stage.completed, Some(false));
+        // assert_eq!(stage.completes_at, None);
+        // assert_eq!(stage.id, Some(115470255));
+        // assert_eq!(stage.metadata.unwrap().ready_for_completion, None);
+        // assert_eq!(
+        //     stage.template_metadata.unwrap().assignable_to,
+        //     Some("any_user".to_string())
+        // );
+        // assert_eq!(stage.stage_type, Some(StageType::Annotate));
 
-        let stage: Stage = serde_json::from_str(contents).unwrap();
-
-        assert_eq!(stage.assignee_id, Some(12974));
-        assert_eq!(stage.completed, Some(false));
-        assert_eq!(stage.completes_at, None);
-        assert_eq!(stage.id, Some(115470255));
-        assert_eq!(stage.metadata.unwrap().ready_for_completion, None);
-        assert_eq!(
-            stage.template_metadata.unwrap().assignable_to,
-            Some("any_user".to_string())
-        );
-        assert_eq!(stage.stage_type, Some(StageType::Annotate));
+        //FIXME
     }
 }


### PR DESCRIPTION
## For the Reviewer

In this repo, we try to follow the [conventional comments](https://conventionalcomments.org/) guidebook when providing feedback to PRs. Please follow the guidebook, to make reviewing a smoother experience for you and me!

## What

Removes deprecated, unsupported darwin v1 api calls and api request and response structures

## Why

You Aren't Going to Need It

