### PR TITLE
fix: update h2 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,9 +477,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
## For the Reviewer

In this repo, we try to follow the [conventional comments](https://conventionalcomments.org/) guidebook when providing feedback to PRs. Please follow the guidebook, to make reviewing a smoother experience for you and me!


## What
```
error[vulnerability]: Degradation of service in h2 servers with CONTINUATION Flood
Error:    ┌─ /home/runner/work/darwin-v7/darwin-v7/Cargo.lock:52:1
   │
52 │ h2 0.4.3 registry+https://github.com/rust-lang/crates.io-index
   │ -------------------------------------------------------------- security vulnerability detected
```
Updates h2 lock version