### PR TITLE
task: Upgrade fake to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
  "syn",
 ]
 
@@ -239,15 +238,15 @@ checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
 
 [[package]]
 name = "deunicode"
-version = "1.4.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e854126756c496b8c81dec88f9a706b15b875c5849d4097a3854476b9fdf94"
+checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
 
 [[package]]
 name = "dummy"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e57e12b69e57fad516e01e2b3960f122696fdb13420e1a88ed8e210316f2876"
+checksum = "07f39256702ef25dc3381a19aece91eb5c803506de0f79b01b6aa0fea64b32c2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -273,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "fake"
-version = "2.9.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c25829bde82205da46e1823b2259db6273379f626fc211f126f65654a2669be"
+checksum = "38bdb1a5a77008bd1208d3fccd90611d7bee8f6d3296175f69fb056747a220fb"
 dependencies = [
  "deunicode",
  "dummy",
@@ -1268,12 +1267,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 anyhow = "1.0"
-fake = { version = "2.9", features = ["derive", "always-true-rng"] }
+fake = { version = "3.0", features = ["derive", "always-true-rng"] }
 reqwest = { version = "0.12", features = ["http2", "json", "macos-system-configuration"], default-features = false }
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## For the Reviewer

In this repo, we try to follow the [conventional comments](https://conventionalcomments.org/) guidebook when providing feedback to PRs. Please follow the guidebook, to make reviewing a smoother experience for you and me!

## What

This PR upgrades `fake` to version `3.0.0`.

## Why

We have upstream repos that would like to upgrade, and this requires `darwin-v7` to be on the same version.
