### PR TITLE
chore: Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,7 @@
 ## v0.6.0
 
 - Bump dependency versions
+
+## v0.7.0
+
+- Bump dependency versions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "darwin-v7"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darwin-v7"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 description = "Unofficial rust client for the [V7 annotation platform](https://darwin.v7labs.com/)"


### PR DESCRIPTION
## What

This PR prepares a release of version `0.7.0` according to `RELEASE.md`.

## Why

So we can have a release with up to date dependencies.
