### PR TITLE
fix: update V7 API response structs

### DIFF
--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -198,8 +198,7 @@ pub struct AnnotationClass {
     // #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
-    // #[serde(skip_serializing_if = "Option::is_none")]
-    pub images: Vec<Option<AnnotationClassImage>>,
+    pub images: Vec<AnnotationClassImage>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inserted_at: Option<String>,

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -160,6 +160,22 @@ pub struct AnnotationDataset {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy)]
+pub struct AnnotationClassImage {
+    pub id: Option<String>,
+    pub index: Option<u32>,
+    pub key: Option<String>,
+    pub y: Option<f64>,
+    pub x: Option<f64>,
+    pub scale: Option<f64>,
+    pub annotation_class_id: Option<u32>,
+    pub crop_key: Option<String>,
+    pub image_height: Option<u32>,
+    pub image_width: Option<u32>,
+    pub crop_url: Option<String>,
+    pub original_image_url: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Dummy)]
 pub struct AnnotationClass {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotation_class_image_url: Option<String>,
@@ -183,7 +199,7 @@ pub struct AnnotationClass {
     pub description: Option<String>,
 
     // #[serde(skip_serializing_if = "Option::is_none")]
-    pub images: Vec<Option<String>>, // TODO: find out what this type is
+    pub images: Vec<Option<AnnotationClassImage>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub inserted_at: Option<String>,

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -21,6 +21,7 @@ pub enum StageType {
     Review,
     Dataset,
     Discard,
+    Sampling,
 }
 
 impl Display for StageType {
@@ -34,6 +35,7 @@ impl Display for StageType {
             StageType::Review => "Review",
             StageType::Dataset => "Dataset",
             StageType::Discard => "Discard",
+            StageType::Sampling => "Sampling",
         };
         write!(f, "{val}")
     }
@@ -131,7 +133,7 @@ pub struct StageConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test_stage_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub threshold: Option<String>,
+    pub threshold: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
     pub x: Option<u32>,


### PR DESCRIPTION
## For the Reviewer

In this repo, we try to follow the [conventional comments](https://conventionalcomments.org/) guidebook when providing feedback to PRs. Please follow the guidebook, to make reviewing a smoother experience for you and me!

## What

Updates the response struct returned from V7 API calls.

## Why

So we receive the correct response struct.



