### PR TITLE
chore: Prepare release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,3 +46,7 @@
 ## v0.8.1
 
 - Fix broken crate publish v0.8.0
+
+## v0.9.0
+
+- Breaking change: A new error type, `DarwinV7Error`, has been introduced. All public APIs now use this error type, rather than `anyhow::Error`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "darwin-v7"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "csv-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darwin-v7"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 description = "Unofficial rust client for the [V7 annotation platform](https://darwin.v7labs.com/)"


### PR DESCRIPTION
## For the Reviewer

In this repo, we try to follow the [conventional comments](https://conventionalcomments.org/) guidebook when providing feedback to PRs. Please follow the guidebook, to make reviewing a smoother experience for you and me!

## What

This PR prepares release `0.9.0` as per `RELEASE.md`.

## Why

We want to ship the new error API.

