### PR TITLE
release: version v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,7 @@
 ## v0.9.0
 
 - Breaking change: A new error type, `DarwinV7Error`, has been introduced. All public APIs now use this error type, rather than `anyhow::Error`.
+
+## v0.9.1
+
+- Marking project as no longer maintained.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "darwin-v7"
-version = "0.9.0"
+version = "0.9.1+deprecated"
 dependencies = [
  "async-trait",
  "csv-async",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "darwin-v7"
-version = "0.9.0"
+version = "0.9.1+deprecated"
 edition = "2021"
 license = "MIT"
 description = "Unofficial rust client for the [V7 annotation platform](https://darwin.v7labs.com/)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # darwin-v7
 
-Unofficial rust client for the [V7 annotation platform](https://darwin.v7labs.com/)
+Unofficial rust client for the [V7 annotation platform](https://darwin.v7labs.com/) (_This project is no longer maintained._)
 
 ## 🚧 UNDER CONSTRUCTION
 


### PR DESCRIPTION
## For the Reviewer

In this repo, we try to follow the [conventional comments](https://conventionalcomments.org/) guidebook when providing feedback to PRs. Please follow the guidebook, to make reviewing a smoother experience for you and me!

## What

Release version 0.9.1 with updates to README to mark crate no longer maintained.